### PR TITLE
[FIX] 주문내역 테이블 DAO 누락된 쿼리 추가

### DIFF
--- a/data/src/main/java/com/woowahan/ordering/data/local/dao/CartDao.kt
+++ b/data/src/main/java/com/woowahan/ordering/data/local/dao/CartDao.kt
@@ -7,10 +7,13 @@ import com.woowahan.ordering.data.entity.CartEntity
 interface CartDao {
     @Insert
     fun insertCart(cart: CartEntity)
+
     @Update
     fun updateCart(cart: CartEntity)
+
     @Delete
     fun deleteCart(cart: CartEntity)
+
     @Query("SELECT * FROM Cart WHERE orderId = null")
     fun getCart(): List<CartEntity>
 }

--- a/data/src/main/java/com/woowahan/ordering/data/local/dao/OrderDao.kt
+++ b/data/src/main/java/com/woowahan/ordering/data/local/dao/OrderDao.kt
@@ -9,7 +9,17 @@ import com.woowahan.ordering.data.entity.SimpleOrderEntity
 interface OrderDao {
     @Insert
     fun insertOrder(order: OrderEntity)
+
+    @Query(
+        "SELECT c.name, c.thumbnail, o.deliveryTime, total(c.price) as totalPrice, count(o.deliveryTime) as productCount " +
+                "FROM Orders as o LEFT JOIN Cart as c ON o.id = c.orderId " +
+                "GROUP BY o.deliveryTime ORDER BY o.deliveryTime DESC"
+    )
     fun getSimpleOrder(): List<SimpleOrderEntity>
-    @Query("SELECT c.* FROM Orders as o LEFT JOIN Cart as c ON o.id = c.orderId WHERE o.deliveryTime = :deliveryTime")
+
+    @Query(
+        "SELECT c.* FROM Orders as o LEFT JOIN Cart as c ON o.id = c.orderId " +
+                "WHERE o.deliveryTime = :deliveryTime ORDER BY o.deliveryTime DESC"
+    )
     fun getOrderedCartByDeliveryTime(deliveryTime: Long): List<CartEntity>
 }

--- a/data/src/main/java/com/woowahan/ordering/data/local/dao/RecentlyDao.kt
+++ b/data/src/main/java/com/woowahan/ordering/data/local/dao/RecentlyDao.kt
@@ -5,16 +5,18 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
 import com.woowahan.ordering.data.entity.RecentlyEntity
-import com.woowahan.ordering.domain.model.Recently
 
 @Dao
 interface RecentlyDao {
     @Insert
     fun insertRecently(recently: RecentlyEntity)
+
     @Update
     fun updateRecently(recently: RecentlyEntity)
+
     @Query("SELECT * FROM Recently ORDER BY latestViewedTime DESC")
     fun getRecently(): List<RecentlyEntity>
+
     @Query("SELECT * FROM Recently ORDER BY latestViewedTime DESC LIMIT :size")
     fun getSimpleRecently(size: Int): List<RecentlyEntity>
 }


### PR DESCRIPTION
## Description
- close #10 
- 누락된 주문내역 요약 조회 쿼리 추가
- 쿼리 결과를 배달 요청시각 최신순으로 정렬
- 메서드 간 공백 추가
- 불필요한 임포트 제거
