### PR TITLE
[FIX] #27 - Spinner Adapter의 변수에 생성된 객체가 존재하지 않을 때만 객체 생성

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/CountAndFilterAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/CountAndFilterAdapter.kt
@@ -14,6 +14,7 @@ class CountAndFilterAdapter :
 
     private var count = 0
     private var onItemSelected: (SortType) -> Unit = {}
+    private lateinit var adapter: FilterAdapter
 
     fun setOnItemSelectedListener(onItemSelected: (SortType) -> Unit) {
         this.onItemSelected = onItemSelected
@@ -32,23 +33,25 @@ class CountAndFilterAdapter :
 
             binding.count = count
 
-            val adapter = FilterAdapter(itemView.context, R.array.spinner)
-            binding.spFilter.adapter = adapter
-            binding.spFilter.onItemSelectedListener =
-                object : AdapterView.OnItemSelectedListener {
-                    override fun onItemSelected(
-                        parent: AdapterView<*>?,
-                        view: View?,
-                        position: Int,
-                        id: Long
-                    ) {
-                        adapter.setCheckedItem(position)
-                        onItemSelected(spinnerList[position])
-                    }
+            if (!this@CountAndFilterAdapter::adapter.isInitialized) {
+                adapter = FilterAdapter(itemView.context, R.array.spinner)
+                binding.spFilter.adapter = adapter
+                binding.spFilter.onItemSelectedListener =
+                    object : AdapterView.OnItemSelectedListener {
+                        override fun onItemSelected(
+                            parent: AdapterView<*>?,
+                            view: View?,
+                            position: Int,
+                            id: Long
+                        ) {
+                            adapter.setCheckedItem(position)
+                            onItemSelected(spinnerList[position])
+                        }
 
-                    override fun onNothingSelected(parent: AdapterView<*>?) {
+                        override fun onNothingSelected(parent: AdapterView<*>?) {
+                        }
                     }
-                }
+            }
 
         }
     }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/FilterAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/FilterAdapter.kt
@@ -43,7 +43,6 @@ class FilterAdapter(
     }
 
     private fun bindTopView(position: Int) = with(topBinding) {
-        checkedItem = position
         tvTitle.text = getItem(position)
     }
 


### PR DESCRIPTION
## Screen Type
- Soup, Side 화면

## Description
- close #27
- Spinner 선택과 동시에 초기값으로 재설정되는 버그

##Task
- Spinner Adapter의 변수에 생성된 객체가 존재하지 않을 때만 객체 생성