### PR TITLE
[FIX] 리니어타입일 때 판매가 컨스트레인트 깨짐 수정

### DIFF
--- a/presentation/src/main/res/layout/item_food_linear.xml
+++ b/presentation/src/main/res/layout/item_food_linear.xml
@@ -95,7 +95,7 @@
             android:lineThrough="@{true}"
             android:text="@{@string/currency_format(food.price)}"
             android:textAppearance="@style/Caption"
-            android:visibility="@{food.price > 0 ? View.VISIBLE : View.GONE}"
+            android:visibility="@{food.price > 0 ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintBottom_toBottomOf="@+id/iv_food"
             app:layout_constraintStart_toStartOf="@+id/tv_discount_rate"
             app:layout_constraintTop_toBottomOf="@+id/tv_discount_rate"

--- a/presentation/src/main/res/layout/item_food_linear.xml
+++ b/presentation/src/main/res/layout/item_food_linear.xml
@@ -66,11 +66,13 @@
             android:id="@+id/tv_discount_rate"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/space_text_horizontal"
             android:text="@{@string/discount_rate_format(food.discountRate)}"
             android:textAppearance="@style/Body2"
             android:textColor="@color/primary_accent"
             android:visibility="@{food.discountRate > 0 ? View.VISIBLE : View.GONE}"
             app:layout_constraintBottom_toTopOf="@id/tv_original_price"
+            app:layout_constraintEnd_toStartOf="@id/tv_discount_price"
             app:layout_constraintStart_toStartOf="@+id/tv_description"
             app:layout_constraintTop_toBottomOf="@+id/tv_description"
             tools:text="20%" />
@@ -79,12 +81,11 @@
             android:id="@+id/tv_discount_price"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/space_text_horizontal"
             android:text="@{@string/currency_format(food.discountedPrice)}"
             android:textAppearance="@style/Body2"
-            app:layout_constraintBottom_toBottomOf="@+id/tv_discount_rate"
+            android:textColor="@color/black"
             app:layout_constraintStart_toEndOf="@id/tv_discount_rate"
-            app:layout_constraintTop_toTopOf="@+id/tv_discount_rate"
+            app:layout_constraintTop_toBottomOf="@id/tv_description"
             tools:text="10,000원" />
 
         <TextView


### PR DESCRIPTION
## Screen Type
- 메인요리

## Description
- close #33 
- 리니어타입일 때 판매가 컨스트레인트 깨짐 수정
- 판매가의 marginStart 를 할인율의 marginEnd 로 이동
