### PR TITLE
[FEAT] 장바구니 바텀시트 데이터 연결

### DIFF
--- a/data/src/main/java/com/woowahan/ordering/data/local/dao/CartDao.kt
+++ b/data/src/main/java/com/woowahan/ordering/data/local/dao/CartDao.kt
@@ -14,6 +14,6 @@ interface CartDao {
     @Delete
     fun deleteCart(cart: CartEntity)
 
-    @Query("SELECT * FROM Cart WHERE orderId = null")
+    @Query("SELECT * FROM Cart WHERE orderId is null")
     fun getCart(): List<CartEntity>
 }

--- a/domain/src/main/java/com/woowahan/ordering/domain/model/Cart.kt
+++ b/domain/src/main/java/com/woowahan/ordering/domain/model/Cart.kt
@@ -7,5 +7,5 @@ data class Cart(
     val price: Long,
     val count: Int,
     val detailHash: String,
-    val isChecked: Boolean
+    val isChecked: Boolean = true
 )

--- a/presentation/src/main/java/com/woowahan/ordering/ui/UiState.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/UiState.kt
@@ -1,0 +1,12 @@
+package com.woowahan.ordering.ui
+
+sealed class UiState {
+    object Loading : UiState()
+    object Success : UiState()
+
+    data class Error(
+        val exception: String
+    ) : UiState()
+
+    object Finished : UiState()
+}

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/BestFoodAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/BestFoodAdapter.kt
@@ -11,9 +11,12 @@ import com.woowahan.ordering.ui.adapter.viewholder.ItemFoodBestViewHolder
 
 class BestFoodAdapter : ListAdapter<Best, ItemFoodBestViewHolder>(bestDiffUtil) {
     private var onDetailClick: (String, String) -> Unit = { _, _ -> }
-    private var onCartClick: (Food) -> Unit = {}
+    private var onCartClick: (Int, Int, Food) -> Unit = { _, _, _ -> }
 
-    fun setOnClick(onDetailClick: (String, String) -> Unit, onCartClick: (Food) -> Unit) {
+    fun setOnClick(
+        onDetailClick: (String, String) -> Unit,
+        onCartClick: (Int, Int, Food) -> Unit
+    ) {
         this.onDetailClick = onDetailClick
         this.onCartClick = onCartClick
     }
@@ -25,6 +28,12 @@ class BestFoodAdapter : ListAdapter<Best, ItemFoodBestViewHolder>(bestDiffUtil) 
     }
 
     override fun onBindViewHolder(holder: ItemFoodBestViewHolder, position: Int) {
-        holder.bind(getItem(position), onDetailClick, onCartClick)
+        holder.bind(
+            getItem(position),
+            onDetailClick = onDetailClick,
+            onCartClick = { itemPos, food ->
+                onCartClick(position, itemPos, food)
+            }
+        )
     }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/FoodAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/FoodAdapter.kt
@@ -13,21 +13,21 @@ class FoodAdapter : ListAdapter<Food, ItemFoodViewHolder>(foodDiffUtil) {
     private var itemViewType: FoodItemViewType = FoodItemViewType.GridItem
 
     private var onDetailClick: (String, String) -> Unit = { _, _ -> }
-    private var onCartClick: (Food) -> Unit = {}
+    private var onCartClick: (Int, Food) -> Unit = { _, _ -> }
 
     fun viewTypeChange(itemViewType: FoodItemViewType) {
         this.itemViewType = itemViewType
         notifyDataSetChanged()
     }
 
-    fun setOnClick(onDetailClick: (String, String) -> Unit, onCartClick: (Food) -> Unit) {
+    fun setOnClick(onDetailClick: (String, String) -> Unit, onCartClick: (Int, Food) -> Unit) {
         this.onDetailClick = onDetailClick
         this.onCartClick = onCartClick
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemFoodViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return when(viewType) {
+        return when (viewType) {
             FoodItemViewType.GridItem.ordinal -> {
                 val binding = ItemFoodGridBinding.inflate(inflater, parent, false)
                 ItemFoodViewHolder.Grid(binding)

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemFoodBestViewHolder.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemFoodBestViewHolder.kt
@@ -10,11 +10,15 @@ import com.woowahan.ordering.util.dp
 
 class ItemFoodBestViewHolder(
     private val binding: ItemFoodBestBinding
-): RecyclerView.ViewHolder(binding.root) {
+) : RecyclerView.ViewHolder(binding.root) {
 
     private val decoration = ItemSpacingDecoratorWithHeader(8.dp)
 
-    fun bind(best: Best, onDetailClick: (String, String) -> Unit, onCartClick: (Food) -> Unit) {
+    fun bind(
+        best: Best,
+        onDetailClick: (String, String) -> Unit,
+        onCartClick: (Int, Food) -> Unit
+    ) {
         val adapter = FoodAdapter()
         adapter.submitList(best.items)
         adapter.setOnClick(onDetailClick, onCartClick)

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemFoodBestViewHolder.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemFoodBestViewHolder.kt
@@ -26,7 +26,9 @@ class ItemFoodBestViewHolder(
         with(binding) {
             title = best.name
             rvProducts.adapter = adapter
-            rvProducts.addItemDecoration(decoration)
+            if (rvProducts.itemDecorationCount == 0) {
+                rvProducts.addItemDecoration(decoration)
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemFoodViewHolder.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemFoodViewHolder.kt
@@ -6,35 +6,42 @@ import com.woowahan.ordering.databinding.ItemFoodGridBinding
 import com.woowahan.ordering.databinding.ItemFoodLinearBinding
 import com.woowahan.ordering.domain.model.Food
 
-sealed class ItemFoodViewHolder(view: View): RecyclerView.ViewHolder(view) {
-    abstract fun bind(food: Food, onDetailClick: (String, String) -> Unit, onCartClick: (Food) -> Unit)
+sealed class ItemFoodViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+    abstract fun bind(
+        food: Food,
+        onDetailClick: (String, String) -> Unit,
+        onCartClick: (Int, Food) -> Unit
+    )
 
-    class Grid(private val binding: ItemFoodGridBinding): ItemFoodViewHolder(binding.root) {
+    class Grid(private val binding: ItemFoodGridBinding) : ItemFoodViewHolder(binding.root) {
         override fun bind(
             food: Food,
             onDetailClick: (String, String) -> Unit,
-            onCartClick: (Food) -> Unit
+            onCartClick: (Int, Food) -> Unit
         ) {
             binding.food = food
             binding.root.setOnClickListener {
                 onDetailClick(food.title, food.detailHash)
             }
             binding.btnAddCart.setOnClickListener {
-                onCartClick(food)
+                onCartClick(bindingAdapterPosition, food)
             }
         }
 
     }
 
-    class Linear(private val binding: ItemFoodLinearBinding): ItemFoodViewHolder(binding.root) {
-        override fun bind(food: Food, onDetailClick: (String, String) -> Unit, onCartClick: (Food) -> Unit) {
+    class Linear(private val binding: ItemFoodLinearBinding) : ItemFoodViewHolder(binding.root) {
+        override fun bind(
+            food: Food,
+            onDetailClick: (String, String) -> Unit,
+            onCartClick: (Int, Food) -> Unit
+        ) {
             binding.food = food
             binding.root.setOnClickListener {
                 onDetailClick(food.title, food.detailHash)
-                onCartClick(food)
             }
             binding.btnAddCart.setOnClickListener {
-                onCartClick(food)
+                onCartClick(bindingAdapterPosition, food)
             }
         }
     }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/dialog/CartBottomSheet.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/dialog/CartBottomSheet.kt
@@ -4,25 +4,104 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woowahan.ordering.R
 import com.woowahan.ordering.databinding.BottomSheetCartBinding
 import com.woowahan.ordering.domain.model.Food
+import com.woowahan.ordering.ui.viewmodel.CartBottomSheetViewModel
+import com.woowahan.ordering.ui.viewmodel.UiState
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
-class CartBottomSheet(
-    private val food: Food
-) : BottomSheetDialogFragment() {
+@AndroidEntryPoint
+class CartBottomSheet : BottomSheetDialogFragment() {
 
-    private lateinit var binding: BottomSheetCartBinding
+    private var binding: BottomSheetCartBinding? = null
+    private val viewModel by viewModels<CartBottomSheetViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View {
+    ): View? {
         binding = DataBindingUtil.inflate(inflater, R.layout.bottom_sheet_cart, container, false)
-        return binding.root
+        return binding?.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding?.let {
+            it.food = food
+            it.vm = viewModel
+            it.lifecycleOwner = viewLifecycleOwner
+        }
+
+        initFlow()
+    }
+
+    private fun initFlow() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { uiState ->
+                    when (uiState) {
+                        is UiState.Loading -> {
+                            showProgressBar()
+                        }
+                        is UiState.Success -> {
+                            hideProgressBar()
+                            onAddAction()
+                            dialog?.dismiss()
+                        }
+                        is UiState.Error -> {
+                            hideProgressBar()
+                            showError(uiState.exception)
+                        }
+                        is UiState.Finished -> {
+                            hideProgressBar()
+                            dialog?.dismiss()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showProgressBar() {
+        binding?.let {
+            it.pbLoading.visibility = View.VISIBLE
+        }
+    }
+
+    private fun hideProgressBar() {
+        binding?.let {
+            it.pbLoading.visibility = View.GONE
+        }
+    }
+
+    private fun showError(message: String) {
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+
+    companion object {
+        lateinit var food: Food
+        lateinit var onAddAction: () -> Unit
+
+        fun newInstance(food: Food, onAddAction: () -> Unit): CartBottomSheet {
+            this.food = food
+            this.onAddAction = onAddAction
+            return CartBottomSheet()
+        }
+    }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/dialog/CartDialogFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/dialog/CartDialogFragment.kt
@@ -1,0 +1,27 @@
+package com.woowahan.ordering.ui.dialog
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.woowahan.ordering.R
+
+class CartDialogFragment : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return MaterialAlertDialogBuilder(requireContext(), R.style.RoundedDialog)
+            .setTitle(R.string.dialog_success_cart_add)
+            .setNegativeButton(R.string.dialog_check_cart) { _, _ -> navigateToCart() }
+            .setPositiveButton(R.string.dialog_keep_shopping) { _, _ -> dismiss() }
+            .create()
+    }
+
+    companion object {
+        lateinit var navigateToCart: () -> Unit
+
+        fun newInstance(navigateToCart: () -> Unit): CartDialogFragment {
+            this.navigateToCart = navigateToCart
+            return CartDialogFragment()
+        }
+    }
+}

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
@@ -4,22 +4,23 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ConcatAdapter
 import com.woowahan.ordering.databinding.FragmentBestBinding
-import com.woowahan.ordering.domain.model.Cart
+import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.ui.adapter.home.BestFoodAdapter
 import com.woowahan.ordering.ui.adapter.home.HeaderAdapter
 import com.woowahan.ordering.ui.dialog.CartBottomSheet
+import com.woowahan.ordering.ui.dialog.CartDialogFragment
 import com.woowahan.ordering.ui.viewmodel.BestViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class BestFragment : Fragment() {
 
-    private lateinit var cartBottomSheet: CartBottomSheet
     private val viewModel: BestViewModel by viewModels()
     private var binding: FragmentBestBinding? = null
     private val adapter: BestFoodAdapter by lazy {
@@ -59,14 +60,31 @@ class BestFragment : Fragment() {
 
     private fun initListener() {
         adapter.setOnClick(onDetailClick) {
-            cartBottomSheet = CartBottomSheet(it)
-            cartBottomSheet.show(parentFragmentManager, "Best")
+            showCartBottomSheet(it)
         }
     }
 
     private fun initRecyclerView() = with(binding!!) {
         val headerAdapter = HeaderAdapter("한 번 주문하면\n두 번 반하는 반찬들", "기획전")
         rvBest.adapter = ConcatAdapter(headerAdapter, adapter)
+    }
+
+    private fun showCartBottomSheet(food: Food) {
+        CartBottomSheet.newInstance(food) {
+            showCartDialog()
+        }.show(parentFragmentManager, tag)
+    }
+
+    private fun showCartDialog() {
+        CartDialogFragment.newInstance {
+            // TODO
+            Toast.makeText(context, "장바구니 화면으로 이동", Toast.LENGTH_SHORT).show()
+        }.show(parentFragmentManager, tag)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
     }
 
     companion object {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
@@ -59,9 +59,12 @@ class BestFragment : Fragment() {
     }
 
     private fun initListener() {
-        adapter.setOnClick(onDetailClick) {
-            showCartBottomSheet(it)
-        }
+        adapter.setOnClick(
+            onDetailClick = onDetailClick,
+            onCartClick = { listPosition, itemPosition, food ->
+                showCartBottomSheet(listPosition, itemPosition, food)
+            }
+        )
     }
 
     private fun initRecyclerView() = with(binding!!) {
@@ -69,8 +72,9 @@ class BestFragment : Fragment() {
         rvBest.adapter = ConcatAdapter(headerAdapter, adapter)
     }
 
-    private fun showCartBottomSheet(food: Food) {
+    private fun showCartBottomSheet(listPosition: Int, itemPosition: Int, food: Food) {
         CartBottomSheet.newInstance(food) {
+            updateFoodState(listPosition, itemPosition)
             showCartDialog()
         }.show(parentFragmentManager, tag)
     }
@@ -80,6 +84,11 @@ class BestFragment : Fragment() {
             // TODO
             Toast.makeText(context, "장바구니 화면으로 이동", Toast.LENGTH_SHORT).show()
         }.show(parentFragmentManager, tag)
+    }
+
+    private fun updateFoodState(listPosition: Int, itemPosition: Int) {
+        adapter.currentList[listPosition].items[itemPosition].isAdded = true
+        adapter.notifyItemChanged(listPosition)
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
@@ -28,7 +28,7 @@ import com.woowahan.ordering.util.dp
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainDishFragment: Fragment() {
+class MainDishFragment : Fragment() {
 
     private var binding: FragmentMainDishBinding? = null
     private val viewModel by viewModels<MainDishViewModel>()
@@ -80,9 +80,12 @@ class MainDishFragment: Fragment() {
     }
 
     private fun initListener() {
-        foodAdapter.setOnClick(onDetailClick) {
-            showCartBottomSheet(it)
-        }
+        foodAdapter.setOnClick(
+            onDetailClick = onDetailClick,
+            onCartClick = { itemPosition, food ->
+                showCartBottomSheet(itemPosition, food)
+            }
+        )
     }
 
     private fun initRecyclerView() = with(binding!!) {
@@ -99,8 +102,7 @@ class MainDishFragment: Fragment() {
                 rvMainDish.removeItemDecoration(linearDecoration)
                 rvMainDish.addItemDecoration(gridDecoration)
                 setGridLayoutManager(concatAdapter)
-            }
-            else {
+            } else {
                 foodAdapter.viewTypeChange(FoodItemViewType.LinearItem)
                 rvMainDish.removeItemDecoration(gridDecoration)
                 rvMainDish.addItemDecoration(linearDecoration)
@@ -127,8 +129,9 @@ class MainDishFragment: Fragment() {
         rvMainDish.layoutManager = LinearLayoutManager(context)
     }
 
-    private fun showCartBottomSheet(food: Food) {
+    private fun showCartBottomSheet(itemPosition: Int, food: Food) {
         CartBottomSheet.newInstance(food) {
+            updateFoodState(itemPosition)
             showCartDialog()
         }.show(parentFragmentManager, tag)
     }
@@ -138,6 +141,11 @@ class MainDishFragment: Fragment() {
             // TODO
             Toast.makeText(context, "장바구니 화면으로 이동", Toast.LENGTH_SHORT).show()
         }.show(parentFragmentManager, tag)
+    }
+
+    private fun updateFoodState(itemPosition: Int) {
+        foodAdapter.currentList[itemPosition].isAdded = true
+        foodAdapter.notifyItemChanged(itemPosition)
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -11,6 +12,7 @@ import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woowahan.ordering.databinding.FragmentMainDishBinding
+import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.domain.model.Menu
 import com.woowahan.ordering.ui.adapter.home.FoodAdapter
 import com.woowahan.ordering.ui.adapter.home.FoodAdapter.FoodItemViewType
@@ -20,14 +22,13 @@ import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader.Companion.GRID
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader.Companion.VERTICAL
 import com.woowahan.ordering.ui.dialog.CartBottomSheet
+import com.woowahan.ordering.ui.dialog.CartDialogFragment
 import com.woowahan.ordering.ui.viewmodel.MainDishViewModel
 import com.woowahan.ordering.util.dp
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainDishFragment: Fragment() {
-
-    private lateinit var cartBottomSheet: CartBottomSheet
 
     private var binding: FragmentMainDishBinding? = null
     private val viewModel by viewModels<MainDishViewModel>()
@@ -80,8 +81,7 @@ class MainDishFragment: Fragment() {
 
     private fun initListener() {
         foodAdapter.setOnClick(onDetailClick) {
-            cartBottomSheet = CartBottomSheet(it)
-            cartBottomSheet.show(parentFragmentManager, "Main")
+            showCartBottomSheet(it)
         }
     }
 
@@ -125,6 +125,19 @@ class MainDishFragment: Fragment() {
 
     private fun setLinearLayoutManager() = with(binding!!) {
         rvMainDish.layoutManager = LinearLayoutManager(context)
+    }
+
+    private fun showCartBottomSheet(food: Food) {
+        CartBottomSheet.newInstance(food) {
+            showCartDialog()
+        }.show(parentFragmentManager, tag)
+    }
+
+    private fun showCartDialog() {
+        CartDialogFragment.newInstance {
+            // TODO
+            Toast.makeText(context, "장바구니 화면으로 이동", Toast.LENGTH_SHORT).show()
+        }.show(parentFragmentManager, tag)
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
@@ -43,7 +43,7 @@ class MainDishFragment: Fragment() {
 
     private val linearDecoration = ItemSpacingDecoratorWithHeader(
         spacing = 18.dp,
-        removeSpacePosition = listOf(0, 1),
+        removeSpacePosition = listOf(0, 1, 2),
         VERTICAL
     )
 

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
@@ -71,9 +71,12 @@ class OtherDishFragment : Fragment() {
     }
 
     private fun initListener() {
-        foodAdapter.setOnClick(onDetailClick) {
-            showCartBottomSheet(it)
-        }
+        foodAdapter.setOnClick(
+            onDetailClick = onDetailClick,
+            onCartClick = { itemPosition, food ->
+                showCartBottomSheet(itemPosition, food)
+            }
+        )
         countAndFilterAdapter.setOnItemSelectedListener {
             viewModel.getMenuList(kind, it)
         }
@@ -100,13 +103,16 @@ class OtherDishFragment : Fragment() {
             layoutDirection = GRID
         )
 
-        rvOtherDish.layoutManager = layoutManager
-        rvOtherDish.adapter = concatAdapter
-        rvOtherDish.addItemDecoration(decoration)
+        rvOtherDish.apply {
+            this.layoutManager = layoutManager
+            this.adapter = concatAdapter
+            addItemDecoration(decoration)
+        }
     }
 
-    private fun showCartBottomSheet(food: Food) {
+    private fun showCartBottomSheet(itemPosition: Int, food: Food) {
         CartBottomSheet.newInstance(food) {
+            updateFoodState(itemPosition)
             showCartDialog()
         }.show(parentFragmentManager, tag)
     }
@@ -116,6 +122,11 @@ class OtherDishFragment : Fragment() {
             // TODO
             Toast.makeText(context, "장바구니 화면으로 이동", Toast.LENGTH_SHORT).show()
         }.show(parentFragmentManager, tag)
+    }
+
+    private fun updateFoodState(itemPosition: Int) {
+        foodAdapter.currentList[itemPosition].isAdded = true
+        foodAdapter.notifyItemChanged(itemPosition)
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -11,12 +12,14 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.GridLayoutManager
 import com.woowahan.ordering.databinding.FragmentOtherDishBinding
+import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.ui.adapter.home.CountAndFilterAdapter
 import com.woowahan.ordering.ui.adapter.home.FoodAdapter
 import com.woowahan.ordering.ui.adapter.home.HeaderAdapter
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader.Companion.GRID
 import com.woowahan.ordering.ui.dialog.CartBottomSheet
+import com.woowahan.ordering.ui.dialog.CartDialogFragment
 import com.woowahan.ordering.ui.fragment.home.other.kind.OtherKind
 import com.woowahan.ordering.ui.viewmodel.OtherDishViewModel
 import com.woowahan.ordering.util.dp
@@ -24,8 +27,6 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class OtherDishFragment : Fragment() {
-
-    private lateinit var cartBottomSheet: CartBottomSheet
 
     private var binding: FragmentOtherDishBinding? = null
     private val viewModel by viewModels<OtherDishViewModel>()
@@ -71,8 +72,7 @@ class OtherDishFragment : Fragment() {
 
     private fun initListener() {
         foodAdapter.setOnClick(onDetailClick) {
-            cartBottomSheet = CartBottomSheet(it)
-            cartBottomSheet.show(parentFragmentManager, "Best")
+            showCartBottomSheet(it)
         }
         countAndFilterAdapter.setOnItemSelectedListener {
             viewModel.getMenuList(kind, it)
@@ -105,6 +105,19 @@ class OtherDishFragment : Fragment() {
         rvOtherDish.addItemDecoration(decoration)
     }
 
+    private fun showCartBottomSheet(food: Food) {
+        CartBottomSheet.newInstance(food) {
+            showCartDialog()
+        }.show(parentFragmentManager, tag)
+    }
+
+    private fun showCartDialog() {
+        CartDialogFragment.newInstance {
+            // TODO
+            Toast.makeText(context, "장바구니 화면으로 이동", Toast.LENGTH_SHORT).show()
+        }.show(parentFragmentManager, tag)
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
@@ -113,9 +126,7 @@ class OtherDishFragment : Fragment() {
     companion object {
         private const val OTHER_KIND = "otherKind"
 
-        fun newInstance(
-            otherKind: OtherKind
-        ) = OtherDishFragment().apply {
+        fun newInstance(otherKind: OtherKind) = OtherDishFragment().apply {
             arguments = bundleOf(OTHER_KIND to otherKind)
         }
     }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/CartBottomSheetViewModel.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/CartBottomSheetViewModel.kt
@@ -6,6 +6,7 @@ import com.woowahan.ordering.domain.model.Cart
 import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.domain.model.Result
 import com.woowahan.ordering.domain.usecase.cart.InsertCartUseCase
+import com.woowahan.ordering.ui.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
@@ -63,15 +64,4 @@ class CartBottomSheetViewModel @Inject constructor(
             }
         }
     }
-}
-
-sealed class UiState {
-    object Loading : UiState()
-    object Success : UiState()
-
-    data class Error(
-        val exception: String
-    ) : UiState()
-
-    object Finished : UiState()
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/CartBottomSheetViewModel.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/CartBottomSheetViewModel.kt
@@ -1,0 +1,82 @@
+package com.woowahan.ordering.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woowahan.ordering.domain.model.Cart
+import com.woowahan.ordering.domain.model.Food
+import com.woowahan.ordering.domain.model.Result
+import com.woowahan.ordering.domain.usecase.cart.InsertCartUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CartBottomSheetViewModel @Inject constructor(
+    private val insertCartUseCase: InsertCartUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableSharedFlow<UiState>()
+    val uiState: SharedFlow<UiState>
+        get() = _uiState
+
+    private var _count = MutableStateFlow(1)
+    val count: StateFlow<Int>
+        get() = _count
+
+    fun increaseCount() {
+        _count.value = _count.value + 1
+    }
+
+    fun decreaseCount() {
+        if (count.value > 1) {
+            _count.value = _count.value - 1
+        }
+    }
+
+    fun cancel() = viewModelScope.launch {
+        _uiState.emit(UiState.Finished)
+    }
+
+    fun addToCart(food: Food) {
+        val cart = Cart(
+            id = 0,
+            title = food.title,
+            thumbnail = food.image,
+            price = food.discountedPrice,
+            count = _count.value,
+            detailHash = food.detailHash
+        )
+
+        viewModelScope.launch(Dispatchers.IO) {
+            insertCartUseCase(cart).collect {
+                when (it) {
+                    is Result.Loading -> {
+                        _uiState.emit(UiState.Loading)
+                    }
+                    is Result.Success -> {
+                        _uiState.emit(UiState.Success)
+                    }
+                    is Result.Failure -> {
+                        _uiState.emit(UiState.Error(it.cause.toString()))
+                    }
+                }
+            }
+        }
+    }
+}
+
+sealed class UiState {
+    object Loading : UiState()
+    object Success : UiState()
+
+    data class Error(
+        val exception: String
+    ) : UiState()
+
+    object Finished : UiState()
+}

--- a/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/CartBottomSheetViewModel.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/CartBottomSheetViewModel.kt
@@ -8,10 +8,7 @@ import com.woowahan.ordering.domain.model.Result
 import com.woowahan.ordering.domain.usecase.cart.InsertCartUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -21,12 +18,10 @@ class CartBottomSheetViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _uiState = MutableSharedFlow<UiState>()
-    val uiState: SharedFlow<UiState>
-        get() = _uiState
+    val uiState = _uiState.asSharedFlow()
 
     private var _count = MutableStateFlow(1)
-    val count: StateFlow<Int>
-        get() = _count
+    val count = _count.asStateFlow()
 
     fun increaseCount() {
         _count.value = _count.value + 1

--- a/presentation/src/main/res/layout/bottom_sheet_cart.xml
+++ b/presentation/src/main/res/layout/bottom_sheet_cart.xml
@@ -5,18 +5,30 @@
 
     <data>
 
-        <variable
-            name="foodItem"
-            type="com.woowahan.ordering.domain.model.Food" />
+        <import type="android.view.View" />
 
         <variable
-            name="count"
-            type="Integer" />
+            name="vm"
+            type="com.woowahan.ordering.ui.viewmodel.CartBottomSheetViewModel" />
+
+        <variable
+            name="food"
+            type="com.woowahan.ordering.domain.model.Food" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
+
+        <ProgressBar
+            android:id="@+id/pb_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/tv_add_cart_title"
@@ -35,6 +47,7 @@
             style="@style/Widget.MaterialComponents.Button.TextButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:onClick="@{() -> vm.cancel()}"
             android:text="@string/bottom_sheet_cancel_button_text"
             android:textColor="@color/black"
             android:textSize="@dimen/size_body2"
@@ -47,6 +60,7 @@
             android:layout_height="60dp"
             android:layout_marginStart="@dimen/space_horizontal"
             android:layout_marginTop="20dp"
+            android:image="@{food.image}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_add_cart_title"
             tools:src="@drawable/ic_launcher_background" />
@@ -57,7 +71,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/space_horizontal"
-            android:text="@{foodItem.title}"
+            android:text="@{food.title}"
             android:textColor="@color/black"
             app:layout_constraintBottom_toTopOf="@+id/tv_discount_rate"
             app:layout_constraintEnd_toEndOf="parent"
@@ -71,8 +85,9 @@
             style="@style/Body2.Bold"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/space_horizontal"
-            android:text="@{@string/discount_rate_format(foodItem.discountRate)}"
+            android:layout_marginStart="@dimen/space_horizontal"
+            android:layout_marginEnd="@dimen/space_text_horizontal"
+            android:text='@{food.discountRate > 0 ? @string/discount_rate_format(food.discountRate) : ""}'
             android:textColor="@color/primary_accent"
             app:layout_constraintBottom_toBottomOf="@id/iv_food"
             app:layout_constraintStart_toEndOf="@id/iv_food"
@@ -85,10 +100,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
-            android:text="@{@string/currency_format(foodItem.discountedPrice)}"
+            android:text="@{@string/currency_format(food.discountedPrice)}"
             android:textColor="@color/black"
             app:layout_constraintBaseline_toBaselineOf="@id/tv_discount_rate"
             app:layout_constraintStart_toEndOf="@id/tv_discount_rate"
+            app:layout_constraintTop_toBottomOf="@id/tv_food_title"
             tools:text="12,640원" />
 
         <TextView
@@ -97,8 +113,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
-            android:text="@{@string/currency_format(foodItem.price)}"
+            android:lineThrough="@{true}"
+            android:text="@{@string/currency_format(food.price)}"
             android:textColor="@color/gray_default"
+            android:visibility="@{food.discountRate > 0 ? View.VISIBLE : View.GONE}"
             app:layout_constraintBaseline_toBaselineOf="@id/tv_discount_rate"
             app:layout_constraintStart_toEndOf="@id/tv_discount_price"
             tools:text="15,800원" />
@@ -110,6 +128,7 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/space_horizontal"
             android:layout_marginVertical="@dimen/space_vertical"
+            android:text="@{@string/currency_format(food.discountedPrice * vm.count)}"
             android:textColor="@color/black"
             app:layout_constraintBaseline_toBaselineOf="@id/tv_count"
             app:layout_constraintStart_toStartOf="parent"
@@ -121,6 +140,7 @@
             android:layout_width="@dimen/rounded_button_size"
             android:layout_height="@dimen/rounded_button_size"
             android:layout_marginHorizontal="@dimen/space_horizontal"
+            android:onClick="@{() -> vm.decreaseCount()}"
             app:icon="@drawable/ic_minus"
             app:layout_constraintBottom_toBottomOf="@id/btn_plus"
             app:layout_constraintEnd_toStartOf="@id/tv_count"
@@ -132,10 +152,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/space_horizontal"
+            android:layout_marginEnd="16dp"
+            android:text="@{vm.count.toString()}"
             android:textColor="@color/black"
             app:layout_constraintBottom_toBottomOf="@id/btn_plus"
             app:layout_constraintEnd_toStartOf="@id/btn_plus"
             app:layout_constraintTop_toTopOf="@id/btn_plus"
+            app:layout_constraintVertical_bias="0.45"
             tools:text="1" />
 
         <com.google.android.material.button.MaterialButton
@@ -145,6 +168,7 @@
             android:layout_height="@dimen/rounded_button_size"
             android:layout_marginHorizontal="@dimen/space_horizontal"
             android:layout_marginVertical="@dimen/space_vertical"
+            android:onClick="@{() -> vm.increaseCount()}"
             app:icon="@drawable/ic_plus"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/iv_food" />
@@ -156,9 +180,10 @@
             android:layout_marginHorizontal="@dimen/space_horizontal"
             android:layout_marginVertical="@dimen/space_vertical"
             android:backgroundTint="@color/primary_main"
+            android:onClick="@{() -> vm.addToCart(food)}"
             android:paddingHorizontal="@dimen/space_horizontal"
             android:paddingVertical="@dimen/space_vertical"
-            android:text="@{@string/bottom_sheet_add_button(count)}"
+            android:text="@{@string/bottom_sheet_add_button(vm.count)}"
             android:textColor="@color/white"
             android:textSize="@dimen/size_subtitle"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/presentation/src/main/res/layout/item_food_grid.xml
+++ b/presentation/src/main/res/layout/item_food_grid.xml
@@ -33,7 +33,9 @@
             android:layout_height="@dimen/rounded_button_size"
             android:layout_marginHorizontal="@dimen/space_horizontal"
             android:layout_marginVertical="@dimen/space_vertical"
-            app:icon="@drawable/ic_cart_disabled"
+            android:backgroundTint="@{food.added ? @color/primary_accent : @color/white}"
+            app:icon="@{food.added ? @drawable/ic_check : @drawable/ic_cart_disabled}"
+            app:iconTint="@{food.added ? @color/white : @color/black}"
             app:layout_constraintBottom_toBottomOf="@+id/iv_food"
             app:layout_constraintEnd_toEndOf="parent" />
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -14,4 +14,7 @@
     <string name="discount_rate_format">%d%%</string>
     <string name="currency_format">%,d원</string>
     <string name="total_count_format">총 %,d개 상품</string>
+    <string name="dialog_success_cart_add">선택한 상품이 장바구니에 담겼습니다.</string>
+    <string name="dialog_keep_shopping">계속 쇼핑하기</string>
+    <string name="dialog_check_cart">장바구니 확인</string>
 </resources>

--- a/presentation/src/main/res/values/style_rounded_dialog.xml
+++ b/presentation/src/main/res/values/style_rounded_dialog.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="RoundedDialog" parent="@style/ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+        <item name="shapeAppearanceOverlay">@style/DialogCorners</item>
+        <item name="buttonBarNegativeButtonStyle">@style/RoundedDialog.Button.Negative</item>
+        <item name="buttonBarPositiveButtonStyle">@style/RoundedDialog.Button.Positive</item>
+    </style>
+
+    <style name="DialogCorners">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">16dp</item>
+    </style>
+
+    <style name="RoundedDialog.Button.Negative" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">@color/black</item>
+    </style>
+
+    <style name="RoundedDialog.Button.Positive" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">@color/primary_accent</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Screen Type
- 장바구니, 메인 화면

## Description
- close #38 
- 장바구니 바텀시트에 아이템 데이터를 연결했습니다.
- 장바구니에 담기 버튼을 누르면 카트 테이블 갱신 후 다이얼로그를 띄웁니다.
- 장바구니에 담긴 아이템은 버튼 상태가 변경되도록 했습니다.
- 기존에 장바구니에 들어있던 아이템도 버튼 상태가 선택된 채로 나타나도록 쿼리를 수정했습니다!

  ```kotlin
  // 변경 전
  @Query("SELECT * FROM Cart WHERE orderId = null")
  fun getCart(): List<CartEntity>

  // 변경 후
  @Query("SELECT * FROM Cart WHERE orderId is null")
  fun getCart(): List<CartEntity>
 
  ```

## 스크린샷
<p align="center">
<img width="250" alt="스크린샷 2022-08-13 오후 5 25 35" src="https://user-images.githubusercontent.com/78132126/184476477-b81e3567-2348-410f-9490-1c41c0fc3546.png">
<img width="250" alt="스크린샷 2022-08-13 오후 5 26 33" src="https://user-images.githubusercontent.com/78132126/184476486-e2883831-f51c-4389-9ef1-15f4f27f5e4d.png">
<img width="250" alt="스크린샷 2022-08-13 오후 5 26 40" src="https://user-images.githubusercontent.com/78132126/184476489-48099a04-a88f-4830-8ca5-e73cdba26de5.png">
</p>

