### PR TITLE
[FIX] #44 - Themes

### DIFF
--- a/presentation/src/main/res/layout/item_food_grid.xml
+++ b/presentation/src/main/res/layout/item_food_grid.xml
@@ -39,7 +39,7 @@
 
         <TextView
             android:id="@+id/tv_title"
-            style="@style/Body2"
+            style="@style/Body2.Bold"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/space_text_vertical"

--- a/presentation/src/main/res/layout/item_food_linear.xml
+++ b/presentation/src/main/res/layout/item_food_linear.xml
@@ -40,10 +40,10 @@
 
         <TextView
             android:id="@+id/tv_title"
-            style="@style/Body2"
+            style="@style/Body2.Bold"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/space_horizontal"
+            android:layout_marginStart="20dp"
             android:text="@{food.title}"
             app:layout_constraintBottom_toTopOf="@id/tv_description"
             app:layout_constraintStart_toEndOf="@id/iv_food"

--- a/presentation/src/main/res/values-night/themes.xml
+++ b/presentation/src/main/res/values-night/themes.xml
@@ -10,6 +10,10 @@
         <!-- Customize your theme here. -->
     </style>
 
+    <style name="Divider">
+        <item name="android:background">@color/line</item>
+    </style>
+
     <style name="ToolbarTheme" parent="ThemeOverlay.AppCompat.ActionBar">
         <item name="android:fontFamily">@font/outfit</item>
         <item name="android:textStyle">bold</item>
@@ -22,43 +26,38 @@
     </style>
 
     <style name="Heading.Bold" parent="Heading">
-        <item name="android:fontWeight">500</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="Subtitle" parent="TextAppearance.AppCompat.Subhead">
-        <item name="android:fontWeight">400</item>
         <item name="android:textSize">@dimen/size_subtitle</item>
     </style>
 
     <style name="Subtitle.Bold" parent="Subtitle">
-        <item name="android:fontWeight">500</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="Body1" parent="TextAppearance.AppCompat.Body1">
-        <item name="android:fontWeight">400</item>
         <item name="android:textSize">@dimen/size_body1</item>
     </style>
 
     <style name="Body1.Bold" parent="Body1">
-        <item name="android:fontWeight">500</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="Body2" parent="TextAppearance.AppCompat.Body2">
-        <item name="android:fontWeight">400</item>
         <item name="android:textSize">@dimen/size_body2</item>
     </style>
 
     <style name="Body2.Bold" parent="Body2">
-        <item name="android:fontWeight">500</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
-
     <style name="Caption" parent="TextAppearance.AppCompat.Caption">
-        <item name="android:fontWeight">400</item>
         <item name="android:textSize">@dimen/size_caption</item>
     </style>
 
     <style name="Caption.Bold" parent="Caption">
-        <item name="android:fontWeight">500</item>
+        <item name="android:textStyle">bold</item>
     </style>
 </resources>

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -27,42 +27,38 @@
     </style>
 
     <style name="Heading.Bold" parent="Heading">
-        <item name="android:fontWeight">500</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="Subtitle" parent="TextAppearance.AppCompat.Subhead">
-        <item name="android:fontWeight">400</item>
         <item name="android:textSize">@dimen/size_subtitle</item>
     </style>
 
     <style name="Subtitle.Bold" parent="Subtitle">
-        <item name="android:fontWeight">500</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="Body1" parent="TextAppearance.AppCompat.Body1">
-        <item name="android:fontWeight">400</item>
         <item name="android:textSize">@dimen/size_body1</item>
     </style>
 
     <style name="Body1.Bold" parent="Body1">
-        <item name="android:fontWeight">500</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="Body2" parent="TextAppearance.AppCompat.Body2">
-        <item name="android:fontWeight">400</item>
         <item name="android:textSize">@dimen/size_body2</item>
     </style>
 
     <style name="Body2.Bold" parent="Body2">
-        <item name="android:fontWeight">500</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="Caption" parent="TextAppearance.AppCompat.Caption">
-        <item name="android:fontWeight">400</item>
         <item name="android:textSize">@dimen/size_caption</item>
     </style>
 
     <style name="Caption.Bold" parent="Caption">
-        <item name="android:fontWeight">500</item>
+        <item name="android:textStyle">bold</item>
     </style>
 </resources>


### PR DESCRIPTION
## About
- closes #44 
- RecyclerView Item, Theme

## Description
- Theme Text Bold 버전의 텍스트가 볼드처리 되지 않습니다.
- 리사이클러뷰 아이템의 제목이 Bold처리 되지 않는 것

## Task
- Theme에 등록된 Bold 스타일의 android:fontWeight가 아닌 android:textStyle 태그 값을 "bold"로 바꿈
- 리사이클러뷰의 아이템 제목의 스타일을 Body2.Bold로 수정
