### PR TITLE
[FIX] #50 - 스피너 초기화 현상

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/CountAndFilterAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/CountAndFilterAdapter.kt
@@ -33,23 +33,24 @@ class CountAndFilterAdapter :
             binding.count = count
 
             val adapter = FilterAdapter(itemView.context, R.array.spinner)
-            binding.spFilter.adapter = adapter
-            binding.spFilter.onItemSelectedListener =
-                object : AdapterView.OnItemSelectedListener {
-                    override fun onItemSelected(
-                        parent: AdapterView<*>?,
-                        view: View?,
-                        position: Int,
-                        id: Long
-                    ) {
-                        adapter.setCheckedItem(position)
-                        onItemSelected(spinnerList[position])
-                    }
+            if (binding.spFilter.adapter == null) {
+                binding.spFilter.adapter = adapter
+                binding.spFilter.onItemSelectedListener =
+                    object : AdapterView.OnItemSelectedListener {
+                        override fun onItemSelected(
+                            parent: AdapterView<*>?,
+                            view: View?,
+                            position: Int,
+                            id: Long
+                        ) {
+                            adapter.setCheckedItem(position)
+                            onItemSelected(spinnerList[position])
+                        }
 
-                    override fun onNothingSelected(parent: AdapterView<*>?) {
+                        override fun onNothingSelected(parent: AdapterView<*>?) {
+                        }
                     }
-                }
-
+            }
         }
     }
 


### PR DESCRIPTION
## Screen Type
- OtherDishFragment

## Description
- close #50
- Spinner가 작동하지 않는 버그

## Task
- notifyDataSetChanged()로 인한 Spinner의 Adapter가 초기화되어 상태가 reset되는 버그 수정