### PR TITLE
[FEAT] 장바구니 목록 기능 구현

### DIFF
--- a/domain/src/main/java/com/woowahan/ordering/domain/model/CartListItem.kt
+++ b/domain/src/main/java/com/woowahan/ordering/domain/model/CartListItem.kt
@@ -1,0 +1,16 @@
+package com.woowahan.ordering.domain.model
+
+sealed class CartListItem {
+    object Header : CartListItem()
+
+    data class Content(
+        val cart: Cart
+    ) : CartListItem()
+
+    data class Footer(
+        val sum: Long,
+        val deliveryFee: Int,
+        val insufficientAmount: Int,
+        val enableToOrder: Boolean
+    ) : CartListItem()
+}

--- a/presentation/src/main/java/com/woowahan/ordering/ui/activity/MainActivity.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/activity/MainActivity.kt
@@ -3,6 +3,7 @@ package com.woowahan.ordering.ui.activity
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.woowahan.ordering.R
@@ -60,6 +61,22 @@ class MainActivity : AppCompatActivity() {
         }
         supportFragmentManager.addOnBackStackChangedListener {
             // 툴바 분기처리
+            supportFragmentManager.fragments.forEach {
+                if (it.isVisible) {
+                    when (it) {
+                        is CartFragment -> {
+                            toolbarHome.isVisible = false
+                            toolbarOrder.isVisible = false
+                            toolbarCart.isVisible = true
+                        }
+                        is HomeFragment -> {
+                            toolbarHome.isVisible = true
+                            toolbarOrder.isVisible = false
+                            toolbarCart.isVisible = false
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/presentation/src/main/java/com/woowahan/ordering/ui/activity/MainActivity.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/activity/MainActivity.kt
@@ -9,8 +9,10 @@ import com.woowahan.ordering.R
 import com.woowahan.ordering.databinding.ActionCartBinding
 import com.woowahan.ordering.databinding.ActionOrderBinding
 import com.woowahan.ordering.databinding.ActivityMainBinding
+import com.woowahan.ordering.ui.fragment.cart.CartFragment
 import com.woowahan.ordering.ui.fragment.home.HomeFragment
 import com.woowahan.ordering.ui.util.add
+import com.woowahan.ordering.ui.util.replace
 import com.woowahan.ordering.ui.viewmodel.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collect
@@ -51,7 +53,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun initListener() = with(binding) {
         cartBinding.ibtCart.setOnClickListener {
-            // 장바구니
+            replaceToCart()
         }
         orderBinding.ibtOrder.setOnClickListener {
             // 주문내역
@@ -67,5 +69,13 @@ class MainActivity : AppCompatActivity() {
                 cartBinding.count = it
             }
         }
+    }
+
+    private fun replaceToCart() {
+        supportFragmentManager.replace(
+            CartFragment::class.java,
+            binding.fcvMain.id,
+            "CartFragment"
+        )
     }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/DiffUtils.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/DiffUtils.kt
@@ -2,7 +2,9 @@ package com.woowahan.ordering.ui.adapter
 
 import androidx.recyclerview.widget.DiffUtil
 import com.woowahan.ordering.domain.model.Best
+import com.woowahan.ordering.domain.model.CartListItem
 import com.woowahan.ordering.domain.model.Food
+import com.woowahan.ordering.domain.model.Recently
 
 val foodDiffUtil = object: DiffUtil.ItemCallback<Food>() {
     override fun areItemsTheSame(oldItem: Food, newItem: Food): Boolean {
@@ -32,4 +34,32 @@ val stringDiffUtil = object: DiffUtil.ItemCallback<String>() {
     override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
         return oldItem == newItem
     }
+}
+
+val cartListDiffUtil = object : DiffUtil.ItemCallback<CartListItem>() {
+    override fun areItemsTheSame(oldItem: CartListItem, newItem: CartListItem): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(oldItem: CartListItem, newItem: CartListItem): Boolean {
+        return if (oldItem is CartListItem.Content && newItem is CartListItem.Content) {
+            oldItem.cart.isChecked == newItem.cart.isChecked
+        } else if (oldItem is CartListItem.Footer && newItem is CartListItem.Footer) {
+            oldItem.sum == newItem.sum
+        } else {
+            oldItem == newItem
+        }
+    }
+
+}
+
+val recentlyDiffUtil = object : DiffUtil.ItemCallback<Recently>() {
+    override fun areItemsTheSame(oldItem: Recently, newItem: Recently): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(oldItem: Recently, newItem: Recently): Boolean {
+        return oldItem.detailHash == newItem.detailHash && oldItem.latestViewedTime == newItem.latestViewedTime
+    }
+
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartAdapter.kt
@@ -1,0 +1,118 @@
+package com.woowahan.ordering.ui.adapter.cart
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.woowahan.ordering.R
+import com.woowahan.ordering.databinding.ItemCartBinding
+import com.woowahan.ordering.databinding.ItemCartHeaderBinding
+import com.woowahan.ordering.databinding.ItemTotalPriceBinding
+import com.woowahan.ordering.domain.model.Cart
+import com.woowahan.ordering.domain.model.CartListItem
+import com.woowahan.ordering.ui.adapter.cartListDiffUtil
+
+class CartAdapter(
+    private val selectAllClick: (Boolean) -> Unit,
+    private val checkItemClick: (Cart) -> Unit,
+    private val minusItemClick: (Cart) -> Unit,
+    private val plusItemClick: (Cart) -> Unit,
+    private val deleteItemClick: (Cart) -> Unit,
+    private val orderClick: () -> Unit
+) : ListAdapter<CartListItem, RecyclerView.ViewHolder>(cartListDiffUtil) {
+
+    class CartHeaderViewHolder(private val binding: ItemCartHeaderBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(selectAllClick: (Boolean) -> Unit) {
+            binding.btnDeselect.setOnClickListener { selectAllClick(true) }
+        }
+    }
+
+    class CartContentViewHolder(private val binding: ItemCartBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(
+            data: CartListItem.Content,
+            checkItemClick: (Cart) -> Unit,
+            minusItemClick: (Cart) -> Unit,
+            plusItemClick: (Cart) -> Unit,
+            deleteItemClick: (Cart) -> Unit,
+        ) = with(binding) {
+            cart = data.cart
+
+            with(data.cart) {
+                ivCheckbox.setOnClickListener { checkItemClick(this) }
+                btnMinus.setOnClickListener { minusItemClick(this) }
+                btnPlus.setOnClickListener { plusItemClick(this) }
+                ibtDelete.setOnClickListener { deleteItemClick(this) }
+            }
+        }
+    }
+
+    class CartTotalViewHolder(private val binding: ItemTotalPriceBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(data: CartListItem.Footer, orderClick: () -> Unit) {
+            with(binding) {
+                isCart = true
+                sumOfPrice = data.sum
+                deliveryFee = data.deliveryFee
+                insufficientAmount = data.insufficientAmount
+                totalPrice = data.sum + data.deliveryFee
+                enableToOrder = data.enableToOrder
+
+                btnOrder.setOnClickListener { orderClick() }
+            }
+        }
+
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder =
+        when (viewType) {
+            R.layout.item_cart -> CartContentViewHolder(
+                ItemCartBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
+            R.layout.item_cart_header -> CartHeaderViewHolder(
+                ItemCartHeaderBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
+            R.layout.item_total_price -> CartTotalViewHolder(
+                ItemTotalPriceBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
+            else -> throw IllegalArgumentException()
+        }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is CartHeaderViewHolder -> holder.bind(selectAllClick)
+            is CartContentViewHolder -> holder.bind(
+                getItem(position) as CartListItem.Content,
+                checkItemClick, minusItemClick, plusItemClick, deleteItemClick
+            )
+            is CartTotalViewHolder -> holder.bind(
+                getItem(position) as CartListItem.Footer,
+                orderClick
+            )
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position)) {
+            is CartListItem.Header -> R.layout.item_cart_header
+            is CartListItem.Content -> R.layout.item_cart
+            is CartListItem.Footer -> R.layout.item_total_price
+        }
+    }
+}

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartRecentlyAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartRecentlyAdapter.kt
@@ -1,0 +1,51 @@
+package com.woowahan.ordering.ui.adapter.cart
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.woowahan.ordering.databinding.ItemCartRecentlyBinding
+import com.woowahan.ordering.domain.model.Recently
+import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader
+import com.woowahan.ordering.util.dp
+
+class CartRecentlyAdapter : RecyclerView.Adapter<CartRecentlyAdapter.CartRecentlyItemViewHolder>() {
+
+    private val recentlyList = mutableListOf<Recently>()
+
+    fun submitList(list: List<Recently>) {
+        recentlyList.clear()
+        recentlyList.addAll(list)
+    }
+
+    class CartRecentlyItemViewHolder(private val binding: ItemCartRecentlyBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        private val decoration = ItemSpacingDecoratorWithHeader(8.dp)
+
+        fun bind(list: List<Recently>) = with(binding) {
+            val adapter = RecentlyAdapter(true)
+            adapter.submitList(list)
+
+            rvRecently.adapter = adapter
+            if (rvRecently.itemDecorationCount == 0) {
+                rvRecently.addItemDecoration(decoration)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CartRecentlyItemViewHolder {
+        return CartRecentlyItemViewHolder(
+            ItemCartRecentlyBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: CartRecentlyItemViewHolder, position: Int) {
+        holder.bind(recentlyList)
+    }
+
+    override fun getItemCount(): Int = 1
+}

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/RecentlyAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/RecentlyAdapter.kt
@@ -1,0 +1,37 @@
+package com.woowahan.ordering.ui.adapter.cart
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.woowahan.ordering.databinding.ItemRecentlyViewedBinding
+import com.woowahan.ordering.domain.model.Recently
+import com.woowahan.ordering.ui.adapter.recentlyDiffUtil
+
+class RecentlyAdapter(
+    private val isCart: Boolean
+) : ListAdapter<Recently, RecentlyAdapter.RecentlyViewHolder>(recentlyDiffUtil) {
+
+    class RecentlyViewHolder(private val binding: ItemRecentlyViewedBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(recently: Recently, isCart: Boolean) = with(binding) {
+            this.recently = recently
+            this.isCart = isCart
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecentlyViewHolder {
+        return RecentlyViewHolder(
+            ItemRecentlyViewedBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: RecentlyViewHolder, position: Int) {
+        holder.bind(getItem(position), isCart)
+    }
+}

--- a/presentation/src/main/java/com/woowahan/ordering/ui/dialog/CartDialogFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/dialog/CartDialogFragment.kt
@@ -11,7 +11,10 @@ class CartDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return MaterialAlertDialogBuilder(requireContext(), R.style.RoundedDialog)
             .setTitle(R.string.dialog_success_cart_add)
-            .setNegativeButton(R.string.dialog_check_cart) { _, _ -> navigateToCart() }
+            .setNegativeButton(R.string.dialog_check_cart) { _, _ ->
+                navigateToCart()
+                dismiss()
+            }
             .setPositiveButton(R.string.dialog_keep_shopping) { _, _ -> dismiss() }
             .create()
     }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/CartFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/CartFragment.kt
@@ -1,0 +1,92 @@
+package com.woowahan.ordering.ui.fragment.cart
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.woowahan.ordering.databinding.FragmentCartBinding
+import com.woowahan.ordering.ui.adapter.cart.CartAdapter
+import com.woowahan.ordering.ui.adapter.cart.CartRecentlyAdapter
+import com.woowahan.ordering.ui.viewmodel.CartViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class CartFragment : Fragment() {
+    private var binding: FragmentCartBinding? = null
+    private val viewModel by viewModels<CartViewModel>()
+    private lateinit var cartAdapter: CartAdapter
+    private lateinit var cartRecentlyAdapter: CartRecentlyAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentCartBinding.inflate(layoutInflater)
+        return binding?.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initRecyclerView()
+        initFlow()
+    }
+
+    private fun initRecyclerView() = with(binding!!) {
+        cartAdapter = CartAdapter(
+            viewModel::selectAll,
+            viewModel::checkItemClick,
+            viewModel::minusItemClick,
+            viewModel::plusItemClick,
+            viewModel::deleteItemClick,
+            viewModel::orderClick
+        )
+        cartRecentlyAdapter = CartRecentlyAdapter()
+        rvCart.adapter = ConcatAdapter(cartAdapter, cartRecentlyAdapter)
+        rvCart.layoutManager = LinearLayoutManager(context)
+    }
+
+    private fun initFlow() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.cartList.collect {
+                    cartAdapter.submitList(it)
+                }
+            }
+        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.recentlyList.collect {
+                    cartRecentlyAdapter.submitList(it)
+                }
+            }
+        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.message.collect {
+                    Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+
+    companion object {
+
+        fun newInstance() = CartFragment()
+    }
+}

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/HomeFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/HomeFragment.kt
@@ -10,6 +10,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.woowahan.ordering.R
 import com.woowahan.ordering.databinding.FragmentHomeBinding
 import com.woowahan.ordering.ui.adapter.home.ViewPagerAdapter
+import com.woowahan.ordering.ui.fragment.cart.CartFragment
 import com.woowahan.ordering.ui.fragment.detail.DetailFragment
 import com.woowahan.ordering.ui.fragment.home.best.BestFragment
 import com.woowahan.ordering.ui.fragment.home.main.MainDishFragment
@@ -21,7 +22,7 @@ class HomeFragment : Fragment() {
 
     private lateinit var binding: FragmentHomeBinding
 
-    private val bestFragment = BestFragment.newInstance()
+    private val bestFragment = BestFragment.newInstance { replaceToCart() }
     private val mainDishFragment = MainDishFragment.newInstance()
     private val soupDishFragment = OtherDishFragment.newInstance(OtherKind.Soup)
     private val sideDishFragment = OtherDishFragment.newInstance(OtherKind.Side)
@@ -59,16 +60,26 @@ class HomeFragment : Fragment() {
         )
     }
 
+    private fun replaceToCart() {
+        parentFragmentManager.replace(
+            CartFragment::class.java,
+            (requireView().parent as View).id,
+            "Cart"
+        )
+    }
+
     private fun initViewPager() = with(binding) {
         val tabs = resources.getStringArray(R.array.tabs)
 
         vpHome.adapter =
-            ViewPagerAdapter(this@HomeFragment, listOf(
-                bestFragment,
-                mainDishFragment,
-                soupDishFragment,
-                sideDishFragment
-            ))
+            ViewPagerAdapter(
+                this@HomeFragment, listOf(
+                    bestFragment,
+                    mainDishFragment,
+                    soupDishFragment,
+                    sideDishFragment
+                )
+            )
 
         tabLayoutMediator = TabLayoutMediator(tlHome, vpHome) { tab, position ->
             tab.text = tabs[position]

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -81,8 +80,7 @@ class BestFragment : Fragment() {
 
     private fun showCartDialog() {
         CartDialogFragment.newInstance {
-            // TODO
-            Toast.makeText(context, "장바구니 화면으로 이동", Toast.LENGTH_SHORT).show()
+            navigateToCart()
         }.show(parentFragmentManager, tag)
     }
 
@@ -97,6 +95,11 @@ class BestFragment : Fragment() {
     }
 
     companion object {
-        fun newInstance() = BestFragment()
+        lateinit var navigateToCart: () -> Unit
+
+        fun newInstance(navigateToCart: () -> Unit) : BestFragment {
+            this.navigateToCart = navigateToCart
+            return BestFragment()
+        }
     }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
@@ -95,7 +95,7 @@ class BestFragment : Fragment() {
     }
 
     companion object {
-        lateinit var navigateToCart: () -> Unit
+        private lateinit var navigateToCart: () -> Unit
 
         fun newInstance(navigateToCart: () -> Unit) : BestFragment {
             this.navigateToCart = navigateToCart

--- a/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/CartViewModel.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/CartViewModel.kt
@@ -1,0 +1,142 @@
+package com.woowahan.ordering.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woowahan.ordering.domain.model.*
+import com.woowahan.ordering.domain.usecase.cart.DeleteCartUseCase
+import com.woowahan.ordering.domain.usecase.cart.GetCartUseCase
+import com.woowahan.ordering.domain.usecase.cart.UpdateCartUseCase
+import com.woowahan.ordering.domain.usecase.order.InsertOrderUseCase
+import com.woowahan.ordering.domain.usecase.recently.GetSimpleRecentlyUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CartViewModel @Inject constructor(
+    private val getCartUseCase: GetCartUseCase,
+    private val updateCartUseCase: UpdateCartUseCase,
+    private val deleteCartUseCase: DeleteCartUseCase,
+    private val insertOrderUseCase: InsertOrderUseCase,
+    private val getSimpleRecentlyUseCase: GetSimpleRecentlyUseCase
+) : ViewModel() {
+
+    private val _cartList = MutableStateFlow<List<CartListItem>>(listOf())
+    val cartList = _cartList.asStateFlow()
+
+    private val _isSelectedAll = MutableStateFlow(true)
+    val isSelectedAll = _isSelectedAll.asStateFlow()
+
+    private val _recentlyList = MutableStateFlow<List<Recently>>(listOf())
+    val recentlyList = _recentlyList.asStateFlow()
+
+    private val _message = MutableSharedFlow<String>()
+    val message = _message.asSharedFlow()
+
+    init {
+        getAllCart()
+        getRecently()
+    }
+
+    fun getAllCart() {
+        viewModelScope.launch(Dispatchers.IO) {
+            getCartUseCase().collect { result ->
+                when (result) {
+                    is Result.Success -> {
+                        val list = result.value
+                        val checkedList = list.filter { it.isChecked }
+
+                        if (list.size > checkedList.size) {
+                            _isSelectedAll.emit(false)
+                        }
+
+                        val sum = checkedList.sumOf { it.price * it.count }
+
+                        val deliveryFee =
+                            if (sum >= DELIVERY_FREE_LIMIT) 0 else DEFAULT_DELIVERY_FEE
+                        val insufficientAmount =
+                            if (sum >= DELIVERY_FREE_LIMIT) 0 else DELIVERY_FREE_LIMIT - sum
+
+                        val mergedList = mutableListOf<CartListItem>().apply {
+                            addAll(list.map { CartListItem.Content(it) })
+                            add(0, CartListItem.Header)
+                            add(
+                                CartListItem.Footer(
+                                    sum = sum,
+                                    deliveryFee = deliveryFee,
+                                    insufficientAmount = insufficientAmount.toInt(),
+                                    enableToOrder = sum >= ORDER_MINIMUM_AMOUNT
+                                )
+                            )
+                        }
+                        _cartList.emit(mergedList)
+                    }
+                }
+            }
+        }
+    }
+
+    fun getRecently() {
+        viewModelScope.launch(Dispatchers.IO) {
+            getSimpleRecentlyUseCase().collect {
+                when (it) {
+                    is Result.Success -> {
+                        _recentlyList.emit(it.value)
+                    }
+                }
+            }
+        }
+    }
+
+    fun selectAll(flag: Boolean) {
+        viewModelScope.launch(Dispatchers.IO) {
+            if (isSelectedAll.value) {
+                _message.emit("selectAll")
+            } else {
+                _message.emit("deselectAll")
+            }
+        }
+    }
+
+    fun checkItemClick(cart: Cart) {
+        viewModelScope.launch(Dispatchers.IO) {
+            _message.emit("item ${cart.detailHash}'s state checked")
+        }
+    }
+
+    fun minusItemClick(cart: Cart) {
+        if (cart.count > 1) {
+            viewModelScope.launch(Dispatchers.IO) {
+                _message.emit("item ${cart.detailHash}'s count decreased")
+            }
+        }
+    }
+
+    fun plusItemClick(cart: Cart) {
+        viewModelScope.launch(Dispatchers.IO) {
+            _message.emit("item ${cart.detailHash}'s count increased")
+        }
+    }
+
+    fun deleteItemClick(cart: Cart) {
+        viewModelScope.launch(Dispatchers.IO) {
+            _message.emit("item ${cart.detailHash} deleted")
+        }
+    }
+
+    fun orderClick() {
+        val order = Order(id = 0, deliveryTime = System.currentTimeMillis())
+        viewModelScope.launch(Dispatchers.IO) {
+            _message.emit("item ordered")
+        }
+    }
+
+
+    companion object {
+        const val DELIVERY_FREE_LIMIT = 40000
+        const val DEFAULT_DELIVERY_FEE = 2500
+        const val ORDER_MINIMUM_AMOUNT = 10000
+    }
+}

--- a/presentation/src/main/res/layout/activity_main.xml
+++ b/presentation/src/main/res/layout/activity_main.xml
@@ -35,10 +35,10 @@
                 android:layout_height="wrap_content"
                 android:background="@color/primary_main"
                 android:theme="@style/ToolbarTheme"
-                app:menu="@menu/menu_toolbar_home"
-                app:title="@string/app_title"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                app:menu="@menu/menu_toolbar_home"
+                app:title="@string/app_title" />
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar_cart"
@@ -46,11 +46,12 @@
                 android:layout_height="wrap_content"
                 android:background="@color/primary_main"
                 android:theme="@style/ToolbarTheme"
-                tools:title="Cart"
                 android:visibility="gone"
-                app:navigationIcon="@drawable/ic_arrow_left"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                app:navigationIcon="@drawable/ic_arrow_left"
+                app:title="Cart"
+                tools:title="Cart" />
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar_order"
@@ -59,10 +60,10 @@
                 android:background="@color/primary_main"
                 android:theme="@style/ToolbarTheme"
                 android:visibility="gone"
-                app:navigationIcon="@drawable/ic_arrow_left"
-                app:menu="@menu/menu_toolbar_order"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                app:menu="@menu/menu_toolbar_order"
+                app:navigationIcon="@drawable/ic_arrow_left" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_cart.xml
+++ b/presentation/src/main/res/layout/fragment_cart.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/surface">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_cart"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Screen Type
- 장바구니

## Description
- close #54 
- 장바구니 화면에서 장바구니 목록과 최근 본 상품 목록을 보여줍니다.
- 메인 화면에서도 장바구니 화면으로 이동할 수 있고, 툴바도 알맞게 변경되도록 했습니다.

## 스크린샷
<img width="386" alt="스크린샷 2022-08-16 오후 4 28 19" src="https://user-images.githubusercontent.com/78132126/184823294-1205deca-915f-45ff-a0da-b6a3a4dff412.png">
