### PR TITLE
[FEAT] 최근 본 상품 화면 구현

### DIFF
--- a/data/src/main/java/com/woowahan/ordering/data/mapper/RecentlyMapper.kt
+++ b/data/src/main/java/com/woowahan/ordering/data/mapper/RecentlyMapper.kt
@@ -1,6 +1,8 @@
 package com.woowahan.ordering.data.mapper
 
 import com.woowahan.ordering.data.entity.RecentlyEntity
+import com.woowahan.ordering.domain.model.Cart
+import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.domain.model.Recently
 
 fun Recently.toEntity(): RecentlyEntity {
@@ -22,5 +24,32 @@ fun RecentlyEntity.toModel(): Recently {
         price,
         discountPrice,
         latestViewedTime
+    )
+}
+
+fun Recently.toCartModel(): Cart {
+    return Cart(
+        id = 0,
+        title = title,
+        thumbnail = thumbnail,
+        price = discountedPrice,
+        count = 1,
+        detailHash = detailHash
+    )
+}
+
+fun Recently.toFoodModel(): Food {
+    return Food(
+        detailHash = detailHash,
+        image = thumbnail,
+        alt = "",
+        deliveryType = listOf(),
+        title = title,
+        description = "",
+        price = price,
+        discountedPrice = discountedPrice,
+        discountRate = (if (price == 0L) 0 else (1 - (discountedPrice.toFloat() / price.toFloat())) * 100).toInt(),
+        badge = listOf(),
+        isAdded = isAdded
     )
 }

--- a/domain/src/main/java/com/woowahan/ordering/domain/model/Recently.kt
+++ b/domain/src/main/java/com/woowahan/ordering/domain/model/Recently.kt
@@ -6,5 +6,6 @@ data class Recently(
     val thumbnail: String,
     val price: Long,
     val discountedPrice: Long,
-    val latestViewedTime: Long
+    val latestViewedTime: Long,
+    var isAdded: Boolean = false
 )

--- a/domain/src/main/java/com/woowahan/ordering/domain/usecase/recently/GetRecentlyUseCase.kt
+++ b/domain/src/main/java/com/woowahan/ordering/domain/usecase/recently/GetRecentlyUseCase.kt
@@ -1,17 +1,27 @@
 package com.woowahan.ordering.domain.usecase.recently
 
 import com.woowahan.ordering.domain.model.Result
+import com.woowahan.ordering.domain.repository.CartRepository
 import com.woowahan.ordering.domain.repository.RecentlyRepository
 import kotlinx.coroutines.flow.flow
 
 class GetRecentlyUseCase(
-    private val repository: RecentlyRepository
+    private val recentlyRepository: RecentlyRepository,
+    private val cartRepository: CartRepository
 ) {
     operator fun invoke() = flow {
         emit(Result.Loading)
         try {
-            emit(Result.Success(repository.getRecently()))
-        } catch(e: Exception) {
+            cartRepository.getCart().collect {
+                val hashList = it.map { cart -> cart.detailHash }
+                val recentlyList = recentlyRepository.getRecently()
+
+                recentlyList.forEach { recently ->
+                    recently.isAdded = hashList.contains(recently.detailHash)
+                }
+                emit(Result.Success(recentlyList))
+            }
+        } catch (e: Exception) {
             emit(Result.Failure(e))
         }
     }

--- a/presentation/src/main/java/com/woowahan/ordering/di/usecase/RecentlyUseCaseModule.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/di/usecase/RecentlyUseCaseModule.kt
@@ -2,10 +2,6 @@ package com.woowahan.ordering.di.usecase
 
 import com.woowahan.ordering.domain.repository.CartRepository
 import com.woowahan.ordering.domain.repository.RecentlyRepository
-import com.woowahan.ordering.domain.usecase.cart.DeleteCartUseCase
-import com.woowahan.ordering.domain.usecase.cart.GetCartUseCase
-import com.woowahan.ordering.domain.usecase.cart.InsertCartUseCase
-import com.woowahan.ordering.domain.usecase.cart.UpdateCartUseCase
 import com.woowahan.ordering.domain.usecase.recently.GetRecentlyUseCase
 import com.woowahan.ordering.domain.usecase.recently.GetSimpleRecentlyUseCase
 import com.woowahan.ordering.domain.usecase.recently.InsertRecentlyUseCase
@@ -33,8 +29,8 @@ object RecentlyUseCaseModule {
 
     @Provides
     @Singleton
-    fun providesGetRecentlyUseCase(repository: RecentlyRepository): GetRecentlyUseCase {
-        return GetRecentlyUseCase(repository)
+    fun providesGetRecentlyUseCase(repository: RecentlyRepository, cartRepository: CartRepository): GetRecentlyUseCase {
+        return GetRecentlyUseCase(repository, cartRepository)
     }
 
     @Provides

--- a/presentation/src/main/java/com/woowahan/ordering/ui/activity/MainActivity.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/activity/MainActivity.kt
@@ -11,6 +11,7 @@ import com.woowahan.ordering.databinding.ActionCartBinding
 import com.woowahan.ordering.databinding.ActionOrderBinding
 import com.woowahan.ordering.databinding.ActivityMainBinding
 import com.woowahan.ordering.ui.fragment.cart.CartFragment
+import com.woowahan.ordering.ui.fragment.cart.recently.RecentlyViewedFragment
 import com.woowahan.ordering.ui.fragment.detail.DetailFragment
 import com.woowahan.ordering.ui.fragment.home.HomeFragment
 import com.woowahan.ordering.ui.fragment.order.OrderListFragment
@@ -80,6 +81,12 @@ class MainActivity : AppCompatActivity() {
                             toolbarOrder.isVisible = false
                             toolbarCart.isVisible = true
                             toolbarCart.title = "Order List"
+                        }
+                        is RecentlyViewedFragment -> {
+                            toolbarHome.isVisible = false
+                            toolbarOrder.isVisible = false
+                            toolbarCart.isVisible = true
+                            toolbarCart.title = "Recently viewed products"
                         }
                         is HomeFragment, is DetailFragment -> {
                             toolbarHome.isVisible = true

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartRecentlyAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartRecentlyAdapter.kt
@@ -8,13 +8,16 @@ import com.woowahan.ordering.domain.model.Recently
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader
 import com.woowahan.ordering.util.dp
 
-class CartRecentlyAdapter : RecyclerView.Adapter<CartRecentlyAdapter.CartRecentlyItemViewHolder>() {
+class CartRecentlyAdapter(
+    private val seeAllClick: () -> Unit
+) : RecyclerView.Adapter<CartRecentlyAdapter.CartRecentlyItemViewHolder>() {
 
     private val recentlyList = mutableListOf<Recently>()
 
     fun submitList(list: List<Recently>) {
         recentlyList.clear()
         recentlyList.addAll(list)
+        notifyDataSetChanged()
     }
 
     class CartRecentlyItemViewHolder(private val binding: ItemCartRecentlyBinding) :
@@ -22,10 +25,11 @@ class CartRecentlyAdapter : RecyclerView.Adapter<CartRecentlyAdapter.CartRecentl
 
         private val decoration = ItemSpacingDecoratorWithHeader(8.dp)
 
-        fun bind(list: List<Recently>) = with(binding) {
+        fun bind(list: List<Recently>, seeAllClick: () -> Unit) = with(binding) {
             val adapter = RecentlyAdapter(true)
             adapter.submitList(list)
 
+            tvSeeAll.setOnClickListener { seeAllClick() }
             rvRecently.adapter = adapter
             if (rvRecently.itemDecorationCount == 0) {
                 rvRecently.addItemDecoration(decoration)
@@ -44,7 +48,7 @@ class CartRecentlyAdapter : RecyclerView.Adapter<CartRecentlyAdapter.CartRecentl
     }
 
     override fun onBindViewHolder(holder: CartRecentlyItemViewHolder, position: Int) {
-        holder.bind(recentlyList)
+        holder.bind(recentlyList, seeAllClick)
     }
 
     override fun getItemCount(): Int = 1

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/RecentlyAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/RecentlyAdapter.kt
@@ -4,20 +4,27 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.woowahan.ordering.data.mapper.toFoodModel
 import com.woowahan.ordering.databinding.ItemRecentlyViewedBinding
+import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.domain.model.Recently
 import com.woowahan.ordering.ui.adapter.recentlyDiffUtil
 
 class RecentlyAdapter(
-    private val isCart: Boolean
+    private val isCart: Boolean,
+    private val cartClick: (Food) -> Unit = {}
 ) : ListAdapter<Recently, RecentlyAdapter.RecentlyViewHolder>(recentlyDiffUtil) {
 
     class RecentlyViewHolder(private val binding: ItemRecentlyViewedBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(recently: Recently, isCart: Boolean) = with(binding) {
+        fun bind(recently: Recently, isCart: Boolean, cartClick: (Food) -> Unit) = with(binding) {
             this.recently = recently
             this.isCart = isCart
+
+            if (!isCart) {
+                btnAddCart.setOnClickListener { cartClick(recently.toFoodModel()) }
+            }
         }
     }
 
@@ -32,6 +39,6 @@ class RecentlyAdapter(
     }
 
     override fun onBindViewHolder(holder: RecentlyViewHolder, position: Int) {
-        holder.bind(getItem(position), isCart)
+        holder.bind(getItem(position), isCart, cartClick)
     }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/CartFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/CartFragment.kt
@@ -15,6 +15,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.woowahan.ordering.databinding.FragmentCartBinding
 import com.woowahan.ordering.ui.adapter.cart.CartAdapter
 import com.woowahan.ordering.ui.adapter.cart.CartRecentlyAdapter
+import com.woowahan.ordering.ui.fragment.cart.recently.RecentlyViewedFragment
+import com.woowahan.ordering.ui.util.replace
 import com.woowahan.ordering.ui.viewmodel.CartViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -52,7 +54,10 @@ class CartFragment : Fragment() {
             viewModel::deleteAll,
             viewModel::orderClick
         )
-        cartRecentlyAdapter = CartRecentlyAdapter()
+        cartRecentlyAdapter = CartRecentlyAdapter {
+            replaceToRecentlyViewed()
+        }
+
         rvCart.adapter = ConcatAdapter(cartAdapter, cartRecentlyAdapter)
         rvCart.layoutManager = LinearLayoutManager(context)
     }
@@ -79,6 +84,14 @@ class CartFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun replaceToRecentlyViewed() {
+        parentFragmentManager.replace(
+            RecentlyViewedFragment::class.java,
+            (requireView().parent as View).id,
+            "RecentlyFragment"
+        )
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/recently/RecentlyViewedFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/recently/RecentlyViewedFragment.kt
@@ -1,0 +1,92 @@
+package com.woowahan.ordering.ui.fragment.cart.recently
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import com.woowahan.ordering.databinding.FragmentRecentlyViewedBinding
+import com.woowahan.ordering.domain.model.Food
+import com.woowahan.ordering.ui.adapter.cart.RecentlyAdapter
+import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader
+import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader.Companion.GRID
+import com.woowahan.ordering.ui.dialog.CartBottomSheet
+import com.woowahan.ordering.ui.dialog.CartDialogFragment
+import com.woowahan.ordering.ui.dialog.IsExistsCartDialogFragment
+import com.woowahan.ordering.ui.viewmodel.RecentlyViewedViewModel
+import com.woowahan.ordering.util.dp
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class RecentlyViewedFragment : Fragment() {
+
+    private var binding: FragmentRecentlyViewedBinding? = null
+    private val viewModel by viewModels<RecentlyViewedViewModel>()
+    private lateinit var adapter: RecentlyAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentRecentlyViewedBinding.inflate(layoutInflater)
+        return binding?.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initRecyclerView()
+        initFlow()
+    }
+
+    private fun initRecyclerView() = with(binding!!) {
+        adapter = RecentlyAdapter(false) {
+            showCartBottomSheet(it)
+        }
+        rvRecently.adapter = adapter
+        rvRecently.addItemDecoration(
+            ItemSpacingDecoratorWithHeader(
+                spacing = 16.dp,
+                layoutDirection = GRID
+            )
+        )
+    }
+
+    private fun initFlow() {
+        lifecycleScope.launchWhenStarted {
+            viewModel.recentlyViewedList.collect {
+                adapter.submitList(it)
+            }
+        }
+    }
+
+    private fun showCartBottomSheet(food: Food) {
+        if (food.isAdded) {
+            IsExistsCartDialogFragment.newInstance {
+                navigateToCart()
+            }.show(parentFragmentManager, tag)
+        } else {
+            CartBottomSheet.newInstance(food) {
+                showCartDialog()
+            }.show(parentFragmentManager, tag)
+        }
+    }
+
+    private fun showCartDialog() {
+        CartDialogFragment.newInstance {
+            navigateToCart()
+        }.show(parentFragmentManager, tag)
+    }
+
+    private fun navigateToCart() {
+        // TODO
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+}

--- a/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/RecentlyViewedViewModel.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/RecentlyViewedViewModel.kt
@@ -1,0 +1,38 @@
+package com.woowahan.ordering.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woowahan.ordering.domain.model.Recently
+import com.woowahan.ordering.domain.model.Result
+import com.woowahan.ordering.domain.usecase.recently.GetRecentlyUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RecentlyViewedViewModel @Inject constructor(
+    private val getRecentlyUseCase: GetRecentlyUseCase
+) : ViewModel() {
+
+    private val _recentlyViewedList = MutableStateFlow<List<Recently>>(listOf())
+    val recentlyViewedList = _recentlyViewedList.asStateFlow()
+
+    init {
+        fetchData()
+    }
+
+    fun fetchData() {
+        viewModelScope.launch(Dispatchers.IO) {
+            getRecentlyUseCase().collect {
+                when (it) {
+                    is Result.Success -> {
+                        _recentlyViewedList.emit(it.value)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/res/layout/fragment_recently_viewed.xml
+++ b/presentation/src/main/res/layout/fragment_recently_viewed.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_recently"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="@dimen/space_vertical"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:spanCount="2"
+            tools:listitem="@layout/item_recently_viewed" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/item_recently_viewed.xml
+++ b/presentation/src/main/res/layout/item_recently_viewed.xml
@@ -41,7 +41,9 @@
             android:layout_height="@dimen/button_size"
             android:layout_marginHorizontal="@dimen/space_horizontal"
             android:layout_marginVertical="@dimen/space_vertical"
-            android:src="@drawable/ic_cart_disabled"
+            android:backgroundTint="@{recently.added ? @color/primary_accent : @color/white}"
+            android:elevation="2dp"
+            android:src="@{recently.added ? @drawable/ic_check : @drawable/ic_cart_disabled}"
             android:visibility="@{isCart ? View.GONE : View.VISIBLE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_food"
             app:layout_constraintEnd_toEndOf="@id/iv_food" />
@@ -76,8 +78,10 @@
             style="@style/Caption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/space_text_horizontal"
             android:lineThrough="@{true}"
             android:text="@{@string/currency_format(recently.price)}"
+            android:visibility="@{recently.price > 0 ? View.VISIBLE : View.GONE}"
             app:layout_constraintBaseline_toBaselineOf="@id/tv_discount_price"
             app:layout_constraintStart_toEndOf="@id/tv_discount_price"
             tools:text="15,800원" />

--- a/presentation/src/main/res/layout/item_recently_viewed.xml
+++ b/presentation/src/main/res/layout/item_recently_viewed.xml
@@ -41,6 +41,7 @@
             android:layout_height="@dimen/button_size"
             android:layout_marginHorizontal="@dimen/space_horizontal"
             android:layout_marginVertical="@dimen/space_vertical"
+            android:tint="@{recently.added ? @color/white : @color/black}"
             android:backgroundTint="@{recently.added ? @color/primary_accent : @color/white}"
             android:elevation="2dp"
             android:src="@{recently.added ? @drawable/ic_check : @drawable/ic_cart_disabled}"


### PR DESCRIPTION
## Screen Type
- 최근 본 상품 화면

## Description
- close #69 
- 최근 본 상품 조회화면을 구현했습니다.
- 해당 화면에서도 아이템이 장바구니에 담겼는지 여부를 알아야 해서 유스케이스를 수정했습니다.
- 고민했던 부분은 장바구니에 담는 바텀시트를 연결할 때 필요한 자료형이 Food인점..

## 스크린샷
<img width="383" alt="스크린샷 2022-08-17 오전 11 39 09" src="https://user-images.githubusercontent.com/78132126/185022508-4d2b64dc-2c57-443f-ba14-619f8cc9bc98.png">

## Todo
- 상세 화면으로 이동
- 백스택 관리
