### PR TITLE
[FIX] #71 - 음식 자세히 보기 화면

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
@@ -36,9 +36,9 @@ class DetailFragment : Fragment() {
     private lateinit var hash: String
     private lateinit var title: String
 
-    private val detailThumbImagesAdapter by lazy { DetailThumbImagesAdapter() }
-    private val detailInfoAdapter by lazy { DetailInfoAdapter(viewModel, title) }
-    private val detailImagesFooterAdapter by lazy { DetailImagesFooterAdapter() }
+    private lateinit var detailThumbImagesAdapter: DetailThumbImagesAdapter
+    private lateinit var detailInfoAdapter: DetailInfoAdapter
+    private lateinit var detailImagesFooterAdapter: DetailImagesFooterAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -111,6 +111,9 @@ class DetailFragment : Fragment() {
     }
 
     private fun initRecyclerView() = with(binding!!) {
+        detailThumbImagesAdapter = DetailThumbImagesAdapter()
+        detailInfoAdapter = DetailInfoAdapter(viewModel, title)
+        detailImagesFooterAdapter = DetailImagesFooterAdapter()
         val adapter = ConcatAdapter(detailThumbImagesAdapter, detailInfoAdapter, detailImagesFooterAdapter)
         rvDetail.adapter = adapter
     }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/DetailViewModel.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/DetailViewModel.kt
@@ -76,7 +76,7 @@ class DetailViewModel @Inject constructor(
         val cart = Cart(
             id = 0,
             title = title,
-            thumbnail = food.topImage,
+            thumbnail = food.thumbImages[0],
             price = food.discountedPrice,
             count = _count.value,
             detailHash = food.hash

--- a/presentation/src/main/res/layout/item_detail_images.xml
+++ b/presentation/src/main/res/layout/item_detail_images.xml
@@ -19,6 +19,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
         android:layout_marginHorizontal="13dp"
+        app:tabRippleColor="@android:color/transparent"
         android:background="@android:color/transparent"
         app:layout_constraintBottom_toBottomOf="@+id/vp_images"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## Screen Type
- DetailFragment

## Description
- close #71
- 음식 자세히 보기 화면 수정

## Task
- 음식 주문 시 thumbnail을 thumbImage의 0번 index 보내기
- 다른 화면 이동 후 종료 시점에 어댑터 초기화하기(lazy 사용하지 않기)
- tabLayout Item Ripple 제거하기