### PR TITLE
[FIX] #73 - 주문 예상 시간 contracts에 추가

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/contracts/Contracts.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/contracts/Contracts.kt
@@ -1,0 +1,3 @@
+package com.woowahan.ordering.ui.contracts
+
+const val DELIVERY_TIME = 1000 * 10

--- a/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/CartViewModel.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/viewmodel/CartViewModel.kt
@@ -6,6 +6,7 @@ import com.woowahan.ordering.domain.model.*
 import com.woowahan.ordering.domain.usecase.cart.*
 import com.woowahan.ordering.domain.usecase.order.InsertOrderUseCase
 import com.woowahan.ordering.domain.usecase.recently.GetSimpleRecentlyUseCase
+import com.woowahan.ordering.ui.contracts.DELIVERY_TIME
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
@@ -142,7 +143,7 @@ class CartViewModel @Inject constructor(
     }
 
     fun orderClick() {
-        val order = Order(id = 0, deliveryTime = System.currentTimeMillis())
+        val order = Order(id = 0, deliveryTime = System.currentTimeMillis() + DELIVERY_TIME)
         viewModelScope.launch(Dispatchers.IO) {
             insertOrderUseCase(order).collect {
                 // TODO
@@ -151,8 +152,8 @@ class CartViewModel @Inject constructor(
     }
 
     companion object {
-        const val DELIVERY_FREE_LIMIT = 40000
-        const val DEFAULT_DELIVERY_FEE = 2500
-        const val ORDER_MINIMUM_AMOUNT = 10000
+        private const val DELIVERY_FREE_LIMIT = 40000
+        private const val DEFAULT_DELIVERY_FEE = 2500
+        private const val ORDER_MINIMUM_AMOUNT = 10000
     }
 }


### PR DESCRIPTION
Co-Authored-By: 주지혜 <oreocube13@gmail.com>

## Screen Type
- close #73
- CartFragment

## Description
- 장바구니 화면 수정

## Task
- [x] 주문 예상 시간을 추가(임시 값으로 현재 시간부터 10초 이후)
