### PR TITLE
[FIX] #84 - 할인율 내림차순 정렬

### DIFF
--- a/domain/src/main/java/com/woowahan/ordering/domain/usecase/food/GetMenuListUseCase.kt
+++ b/domain/src/main/java/com/woowahan/ordering/domain/usecase/food/GetMenuListUseCase.kt
@@ -37,7 +37,7 @@ class GetMenuListUseCase(
                         result.sortedBy { it.discountedPrice }
                     }
                     is SortType.RateDesc -> {
-                        result.sortedBy { it.discountRate }
+                        result.sortedByDescending { it.discountRate }
                     }
                 }
                 emit(Result.Success(sortedList))


### PR DESCRIPTION
## Screen Type
- 메인화면

## Description
- close #84 
- 할인율이 오름차순으로 정렬되고 있던 오류 수정
