### PR TITLE
[REFECTOR] #92 - RecentlyAdapter 리팩토링 및 클릭 시 바텀 시트, 화면 이동 구현

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartRecentlyAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartRecentlyAdapter.kt
@@ -26,7 +26,7 @@ class CartRecentlyAdapter(
         private val decoration = ItemSpacingDecoratorWithHeader(8.dp)
 
         fun bind(list: List<Recently>, seeAllClick: () -> Unit) = with(binding) {
-            val adapter = RecentlyAdapter(true)
+            val adapter = RecentlyAdapter()
             adapter.submitList(list)
 
             tvSeeAll.setOnClickListener { seeAllClick() }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartRecentlyAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartRecentlyAdapter.kt
@@ -4,11 +4,13 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.woowahan.ordering.databinding.ItemCartRecentlyBinding
+import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.domain.model.Recently
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader
 import com.woowahan.ordering.util.dp
 
 class CartRecentlyAdapter(
+    private val onDetailClick: (String, String) -> Unit,
     private val seeAllClick: () -> Unit
 ) : RecyclerView.Adapter<CartRecentlyAdapter.CartRecentlyItemViewHolder>() {
 
@@ -20,14 +22,15 @@ class CartRecentlyAdapter(
         notifyDataSetChanged()
     }
 
-    class CartRecentlyItemViewHolder(private val binding: ItemCartRecentlyBinding) :
+    inner class CartRecentlyItemViewHolder(private val binding: ItemCartRecentlyBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
         private val decoration = ItemSpacingDecoratorWithHeader(8.dp)
 
         fun bind(list: List<Recently>, seeAllClick: () -> Unit) = with(binding) {
-            val adapter = RecentlyAdapter()
+            val adapter = RecentlyAdapter(RecentlyAdapter.RecentlyItemViewType.HorizontalItem)
             adapter.submitList(list)
+            adapter.setOnClick(onDetailClick)
 
             tvSeeAll.setOnClickListener { seeAllClick() }
             rvRecently.adapter = adapter

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/RecentlyAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/RecentlyAdapter.kt
@@ -3,42 +3,52 @@ package com.woowahan.ordering.ui.adapter.cart
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
-import androidx.recyclerview.widget.RecyclerView
-import com.woowahan.ordering.data.mapper.toFoodModel
-import com.woowahan.ordering.databinding.ItemRecentlyViewedBinding
+import com.woowahan.ordering.databinding.ItemRecentlyGridBinding
+import com.woowahan.ordering.databinding.ItemRecentlyHorizontalBinding
 import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.domain.model.Recently
+import com.woowahan.ordering.ui.adapter.home.FoodAdapter
 import com.woowahan.ordering.ui.adapter.recentlyDiffUtil
+import com.woowahan.ordering.ui.adapter.viewholder.ItemRecentlyViewHolder
 
 class RecentlyAdapter(
-    private val isCart: Boolean,
-    private val cartClick: (Food) -> Unit = {}
-) : ListAdapter<Recently, RecentlyAdapter.RecentlyViewHolder>(recentlyDiffUtil) {
+    private var itemViewType: FoodAdapter.FoodItemViewType = FoodAdapter.FoodItemViewType.GridItem
+) : ListAdapter<Recently, ItemRecentlyViewHolder>(recentlyDiffUtil) {
 
-    class RecentlyViewHolder(private val binding: ItemRecentlyViewedBinding) :
-        RecyclerView.ViewHolder(binding.root) {
+    private var onDetailClick: (String, String) -> Unit = { _, _ -> }
+    private var onCartClick: (Food) -> Unit = {}
 
-        fun bind(recently: Recently, isCart: Boolean, cartClick: (Food) -> Unit) = with(binding) {
-            this.recently = recently
-            this.isCart = isCart
+    fun setOnClick(onDetailClick: (String, String) -> Unit, onCartClick: (Food) -> Unit) {
+        this.onDetailClick = onDetailClick
+        this.onCartClick = onCartClick
+    }
 
-            if (!isCart) {
-                btnAddCart.setOnClickListener { cartClick(recently.toFoodModel()) }
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemRecentlyViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return when(viewType) {
+            RecentlyItemViewType.GridItem.ordinal -> {
+                val binding = ItemRecentlyGridBinding.inflate(inflater, parent, false)
+                ItemRecentlyViewHolder.Grid(binding)
+            }
+            RecentlyItemViewType.HorizontalItem.ordinal -> {
+                val binding = ItemRecentlyHorizontalBinding.inflate(inflater, parent, false)
+                ItemRecentlyViewHolder.Horizontal(binding)
+            }
+            else -> {
+                throw IllegalArgumentException()
             }
         }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecentlyViewHolder {
-        return RecentlyViewHolder(
-            ItemRecentlyViewedBinding.inflate(
-                LayoutInflater.from(parent.context),
-                parent,
-                false
-            )
-        )
+    override fun onBindViewHolder(holder: ItemRecentlyViewHolder, position: Int) {
+        holder.bind(getItem(position), onDetailClick, onCartClick)
     }
 
-    override fun onBindViewHolder(holder: RecentlyViewHolder, position: Int) {
-        holder.bind(getItem(position), isCart, cartClick)
+    override fun getItemViewType(position: Int): Int {
+        return itemViewType.ordinal
+    }
+
+    enum class RecentlyItemViewType {
+        GridItem, HorizontalItem
     }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/RecentlyAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/RecentlyAdapter.kt
@@ -7,18 +7,17 @@ import com.woowahan.ordering.databinding.ItemRecentlyGridBinding
 import com.woowahan.ordering.databinding.ItemRecentlyHorizontalBinding
 import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.domain.model.Recently
-import com.woowahan.ordering.ui.adapter.home.FoodAdapter
 import com.woowahan.ordering.ui.adapter.recentlyDiffUtil
 import com.woowahan.ordering.ui.adapter.viewholder.ItemRecentlyViewHolder
 
 class RecentlyAdapter(
-    private var itemViewType: FoodAdapter.FoodItemViewType = FoodAdapter.FoodItemViewType.GridItem
+    private var itemViewType: RecentlyItemViewType = RecentlyItemViewType.GridItem
 ) : ListAdapter<Recently, ItemRecentlyViewHolder>(recentlyDiffUtil) {
 
     private var onDetailClick: (String, String) -> Unit = { _, _ -> }
     private var onCartClick: (Food) -> Unit = {}
 
-    fun setOnClick(onDetailClick: (String, String) -> Unit, onCartClick: (Food) -> Unit) {
+    fun setOnClick(onDetailClick: (String, String) -> Unit, onCartClick: (Food) -> Unit = {}) {
         this.onDetailClick = onDetailClick
         this.onCartClick = onCartClick
     }
@@ -41,7 +40,10 @@ class RecentlyAdapter(
     }
 
     override fun onBindViewHolder(holder: ItemRecentlyViewHolder, position: Int) {
-        holder.bind(getItem(position), onDetailClick, onCartClick)
+        when(holder) {
+            is ItemRecentlyViewHolder.Grid -> holder.bind(getItem(position), onDetailClick, onCartClick)
+            is ItemRecentlyViewHolder.Horizontal -> holder.bind(getItem(position), onDetailClick)
+        }
     }
 
     override fun getItemViewType(position: Int): Int {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemRecentlyViewHolder.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemRecentlyViewHolder.kt
@@ -40,9 +40,6 @@ sealed class ItemRecentlyViewHolder(view: View) : RecyclerView.ViewHolder(view) 
             binding.root.setOnClickListener {
                 onDetailClick(recently.title, recently.detailHash)
             }
-            binding.btnAddCart.setOnClickListener {
-                onCartClick(recently.toFoodModel())
-            }
         }
     }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemRecentlyViewHolder.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemRecentlyViewHolder.kt
@@ -1,0 +1,48 @@
+package com.woowahan.ordering.ui.adapter.viewholder
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.woowahan.ordering.data.mapper.toFoodModel
+import com.woowahan.ordering.databinding.*
+import com.woowahan.ordering.domain.model.Food
+import com.woowahan.ordering.domain.model.Recently
+
+sealed class ItemRecentlyViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+    abstract fun bind(
+        recently: Recently,
+        onDetailClick: (String, String) -> Unit,
+        onCartClick: (Food) -> Unit
+    )
+
+    class Grid(private val binding: ItemRecentlyGridBinding) : ItemRecentlyViewHolder(binding.root) {
+        override fun bind(
+            recently: Recently,
+            onDetailClick: (String, String) -> Unit,
+            onCartClick: (Food) -> Unit
+        ) {
+            binding.recently = recently
+            binding.root.setOnClickListener {
+                onDetailClick(recently.title, recently.detailHash)
+            }
+            binding.btnAddCart.setOnClickListener {
+                onCartClick(recently.toFoodModel())
+            }
+        }
+    }
+
+    class Horizontal(private val binding: ItemRecentlyHorizontalBinding) : ItemRecentlyViewHolder(binding.root) {
+        override fun bind(
+            recently: Recently,
+            onDetailClick: (String, String) -> Unit,
+            onCartClick: (Food) -> Unit
+        ) {
+            binding.recently = recently
+            binding.root.setOnClickListener {
+                onDetailClick(recently.title, recently.detailHash)
+            }
+            binding.btnAddCart.setOnClickListener {
+                onCartClick(recently.toFoodModel())
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemRecentlyViewHolder.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemRecentlyViewHolder.kt
@@ -8,14 +8,9 @@ import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.domain.model.Recently
 
 sealed class ItemRecentlyViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-    abstract fun bind(
-        recently: Recently,
-        onDetailClick: (String, String) -> Unit,
-        onCartClick: (Food) -> Unit
-    )
 
     class Grid(private val binding: ItemRecentlyGridBinding) : ItemRecentlyViewHolder(binding.root) {
-        override fun bind(
+        fun bind(
             recently: Recently,
             onDetailClick: (String, String) -> Unit,
             onCartClick: (Food) -> Unit
@@ -31,10 +26,9 @@ sealed class ItemRecentlyViewHolder(view: View) : RecyclerView.ViewHolder(view) 
     }
 
     class Horizontal(private val binding: ItemRecentlyHorizontalBinding) : ItemRecentlyViewHolder(binding.root) {
-        override fun bind(
+        fun bind(
             recently: Recently,
-            onDetailClick: (String, String) -> Unit,
-            onCartClick: (Food) -> Unit
+            onDetailClick: (String, String) -> Unit
         ) {
             binding.recently = recently
             binding.root.setOnClickListener {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/CartFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/CartFragment.kt
@@ -29,6 +29,7 @@ import com.woowahan.ordering.ui.receiver.CartReceiver.Companion.FOOD_COUNT
 import com.woowahan.ordering.ui.receiver.CartReceiver.Companion.FOOD_TITLE
 import com.woowahan.ordering.util.replace
 import com.woowahan.ordering.ui.viewmodel.CartViewModel
+import com.woowahan.ordering.util.clearAllBackStack
 import com.woowahan.ordering.util.startAlarmReceiver
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -127,6 +128,7 @@ class CartFragment : Fragment() {
     }
 
     private fun replaceToDetail(title: String, hash: String) {
+        parentFragmentManager.clearAllBackStack(tag)
         parentFragmentManager.replace(
             DetailFragment::class.java,
             (requireView().parent as View).id,

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/CartFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/CartFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -18,6 +19,8 @@ import com.woowahan.ordering.databinding.FragmentCartBinding
 import com.woowahan.ordering.ui.adapter.cart.CartAdapter
 import com.woowahan.ordering.ui.adapter.cart.CartRecentlyAdapter
 import com.woowahan.ordering.ui.fragment.cart.recently.RecentlyViewedFragment
+import com.woowahan.ordering.ui.fragment.detail.DetailFragment
+import com.woowahan.ordering.ui.fragment.home.HomeFragment
 import com.woowahan.ordering.ui.receiver.CartReceiver
 import com.woowahan.ordering.ui.receiver.CartReceiver.Companion.DELIVERY_FINISHED_TIME
 import com.woowahan.ordering.ui.receiver.CartReceiver.Companion.FOOD_COUNT
@@ -51,7 +54,7 @@ class CartFragment : Fragment() {
         initFlow()
     }
 
-    private fun initRecyclerView() = with(binding!!) {
+    private fun initRecyclerView() {
         cartAdapter = CartAdapter(
             viewModel::selectAll,
             viewModel::checkItemClick,
@@ -65,13 +68,17 @@ class CartFragment : Fragment() {
                 createNotificationTray(title, count, deliveryTime)
             }
         )
-        cartRecentlyAdapter = CartRecentlyAdapter {
-            replaceToRecentlyViewed()
-        }
 
-        rvCart.adapter = ConcatAdapter(cartAdapter, cartRecentlyAdapter)
-        rvCart.layoutManager = LinearLayoutManager(context)
-        rvCart.itemAnimator = null
+        cartRecentlyAdapter = CartRecentlyAdapter(
+            onDetailClick = this::replaceToDetail,
+            seeAllClick = this::replaceToRecentlyViewed
+        )
+
+        with(binding!!) {
+            rvCart.adapter = ConcatAdapter(cartAdapter, cartRecentlyAdapter)
+            rvCart.layoutManager = LinearLayoutManager(context)
+            rvCart.itemAnimator = null
+        }
     }
 
     private fun createNotificationTray(title: String, count: Int, deliveryTime: Long) {
@@ -114,6 +121,15 @@ class CartFragment : Fragment() {
             RecentlyViewedFragment::class.java,
             (requireView().parent as View).id,
             "RecentlyFragment"
+        )
+    }
+
+    private fun replaceToDetail(title: String, hash: String) {
+        parentFragmentManager.replace(
+            DetailFragment::class.java,
+            (requireView().parent as View).id,
+            "Detail",
+            bundleOf(HomeFragment.TITLE to title, HomeFragment.HASH to hash)
         )
     }
 

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/CartFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/CartFragment.kt
@@ -20,6 +20,8 @@ import com.woowahan.ordering.ui.adapter.cart.CartAdapter
 import com.woowahan.ordering.ui.adapter.cart.CartRecentlyAdapter
 import com.woowahan.ordering.ui.fragment.cart.recently.RecentlyViewedFragment
 import com.woowahan.ordering.ui.fragment.detail.DetailFragment
+import com.woowahan.ordering.ui.fragment.detail.DetailFragment.Companion.HASH
+import com.woowahan.ordering.ui.fragment.detail.DetailFragment.Companion.TITLE
 import com.woowahan.ordering.ui.fragment.home.HomeFragment
 import com.woowahan.ordering.ui.receiver.CartReceiver
 import com.woowahan.ordering.ui.receiver.CartReceiver.Companion.DELIVERY_FINISHED_TIME
@@ -129,7 +131,7 @@ class CartFragment : Fragment() {
             DetailFragment::class.java,
             (requireView().parent as View).id,
             "Detail",
-            bundleOf(HomeFragment.TITLE to title, HomeFragment.HASH to hash)
+            bundleOf(TITLE to title, HASH to hash)
         )
     }
 

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/recently/RecentlyViewedFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/recently/RecentlyViewedFragment.kt
@@ -22,6 +22,7 @@ import com.woowahan.ordering.ui.fragment.detail.DetailFragment.Companion.HASH
 import com.woowahan.ordering.ui.fragment.detail.DetailFragment.Companion.TITLE
 import com.woowahan.ordering.ui.fragment.home.HomeFragment
 import com.woowahan.ordering.ui.viewmodel.RecentlyViewedViewModel
+import com.woowahan.ordering.util.clearAllBackStack
 import com.woowahan.ordering.util.dp
 import com.woowahan.ordering.util.replace
 import dagger.hilt.android.AndroidEntryPoint
@@ -87,6 +88,7 @@ class RecentlyViewedFragment : Fragment() {
     }
 
     private fun replaceToCart() {
+        parentFragmentManager.clearAllBackStack(tag)
         parentFragmentManager.replace(
             CartFragment::class.java,
             (requireView().parent as View).id,
@@ -95,6 +97,7 @@ class RecentlyViewedFragment : Fragment() {
     }
 
     private fun replaceToDetail(title: String, hash: String) {
+        parentFragmentManager.clearAllBackStack(tag)
         parentFragmentManager.replace(
             DetailFragment::class.java,
             (requireView().parent as View).id,

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/recently/RecentlyViewedFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/recently/RecentlyViewedFragment.kt
@@ -43,9 +43,7 @@ class RecentlyViewedFragment : Fragment() {
     }
 
     private fun initRecyclerView() = with(binding!!) {
-        adapter = RecentlyAdapter(false) {
-            showCartBottomSheet(it)
-        }
+        adapter = RecentlyAdapter()
         rvRecently.adapter = adapter
         rvRecently.addItemDecoration(
             ItemSpacingDecoratorWithHeader(

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/recently/RecentlyViewedFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/recently/RecentlyViewedFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -15,8 +16,14 @@ import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader.Compani
 import com.woowahan.ordering.ui.dialog.CartBottomSheet
 import com.woowahan.ordering.ui.dialog.CartDialogFragment
 import com.woowahan.ordering.ui.dialog.IsExistsCartDialogFragment
+import com.woowahan.ordering.ui.fragment.cart.CartFragment
+import com.woowahan.ordering.ui.fragment.detail.DetailFragment
+import com.woowahan.ordering.ui.fragment.detail.DetailFragment.Companion.HASH
+import com.woowahan.ordering.ui.fragment.detail.DetailFragment.Companion.TITLE
+import com.woowahan.ordering.ui.fragment.home.HomeFragment
 import com.woowahan.ordering.ui.viewmodel.RecentlyViewedViewModel
 import com.woowahan.ordering.util.dp
+import com.woowahan.ordering.util.replace
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -64,7 +71,7 @@ class RecentlyViewedFragment : Fragment() {
     private fun showCartBottomSheet(food: Food) {
         if (food.isAdded) {
             IsExistsCartDialogFragment.newInstance {
-                navigateToCart()
+                replaceToCart()
             }.show(parentFragmentManager, tag)
         } else {
             CartBottomSheet.newInstance(food) {
@@ -75,12 +82,25 @@ class RecentlyViewedFragment : Fragment() {
 
     private fun showCartDialog() {
         CartDialogFragment.newInstance {
-            navigateToCart()
+            replaceToCart()
         }.show(parentFragmentManager, tag)
     }
 
-    private fun navigateToCart() {
-        // TODO
+    private fun replaceToCart() {
+        parentFragmentManager.replace(
+            CartFragment::class.java,
+            (requireView().parent as View).id,
+            "Cart",
+        )
+    }
+
+    private fun replaceToDetail(title: String, hash: String) {
+        parentFragmentManager.replace(
+            DetailFragment::class.java,
+            (requireView().parent as View).id,
+            "Detail",
+            bundleOf(TITLE to title, HASH to hash)
+        )
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
@@ -18,8 +18,6 @@ import com.woowahan.ordering.ui.adapter.detail.DetailThumbImagesAdapter
 import com.woowahan.ordering.ui.dialog.CartDialogFragment
 import com.woowahan.ordering.ui.dialog.IsExistsCartDialogFragment
 import com.woowahan.ordering.ui.fragment.cart.CartFragment
-import com.woowahan.ordering.ui.fragment.home.HomeFragment.Companion.HASH
-import com.woowahan.ordering.ui.fragment.home.HomeFragment.Companion.TITLE
 import com.woowahan.ordering.ui.uistate.DetailUiState
 import com.woowahan.ordering.util.replace
 import com.woowahan.ordering.ui.viewmodel.DetailViewModel
@@ -128,5 +126,10 @@ class DetailFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
+    }
+
+    companion object {
+        const val TITLE = "title"
+        const val HASH = "hash"
     }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/HomeFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/HomeFragment.kt
@@ -12,6 +12,8 @@ import com.woowahan.ordering.databinding.FragmentHomeBinding
 import com.woowahan.ordering.ui.adapter.home.ViewPagerAdapter
 import com.woowahan.ordering.ui.fragment.cart.CartFragment
 import com.woowahan.ordering.ui.fragment.detail.DetailFragment
+import com.woowahan.ordering.ui.fragment.detail.DetailFragment.Companion.HASH
+import com.woowahan.ordering.ui.fragment.detail.DetailFragment.Companion.TITLE
 import com.woowahan.ordering.ui.fragment.home.best.BestFragment
 import com.woowahan.ordering.ui.fragment.home.main.MainDishFragment
 import com.woowahan.ordering.ui.fragment.home.other.OtherDishFragment
@@ -90,10 +92,5 @@ class HomeFragment : Fragment() {
     override fun onDestroy() {
         tabLayoutMediator.detach()
         super.onDestroy()
-    }
-
-    companion object {
-        const val TITLE = "title"
-        const val HASH = "hash"
     }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/util/FragmentReplace.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/util/FragmentReplace.kt
@@ -37,3 +37,7 @@ fun <T: Fragment> FragmentManager.replace(
         commit()
     }
 }
+
+fun FragmentManager.clearAllBackStack(tag: String? = "") {
+    popBackStack(tag, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+}

--- a/presentation/src/main/res/layout/fragment_recently_viewed.xml
+++ b/presentation/src/main/res/layout/fragment_recently_viewed.xml
@@ -20,7 +20,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:spanCount="2"
-            tools:listitem="@layout/item_recently_viewed" />
+            tools:listitem="@layout/item_recently_grid" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/item_cart_recently.xml
+++ b/presentation/src/main/res/layout/item_cart_recently.xml
@@ -47,7 +47,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_recently_title"
-            tools:listitem="@layout/item_recently_viewed" />
+            tools:listitem="@layout/item_recently_horizontal" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/item_recently_grid.xml
+++ b/presentation/src/main/res/layout/item_recently_grid.xml
@@ -8,20 +8,13 @@
         <import type="android.view.View" />
 
         <variable
-            name="isCart"
-            type="Boolean" />
-
-        <variable
             name="recently"
             type="com.woowahan.ordering.domain.model.Recently" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:match_parent="@{!isCart}"
-        app:width="@{@dimen/cart_recent_list_image_size}"
-        tools:layout_width="match_parent">
+        android:layout_height="wrap_content">
 
         <ImageView
             android:id="@+id/iv_food"
@@ -45,7 +38,6 @@
             android:backgroundTint="@{recently.added ? @color/primary_accent : @color/white}"
             android:elevation="2dp"
             android:src="@{recently.added ? @drawable/ic_check : @drawable/ic_cart_disabled}"
-            android:visibility="@{isCart ? View.GONE : View.VISIBLE}"
             app:layout_constraintBottom_toBottomOf="@id/iv_food"
             app:layout_constraintEnd_toEndOf="@id/iv_food" />
 

--- a/presentation/src/main/res/layout/item_recently_horizontal.xml
+++ b/presentation/src/main/res/layout/item_recently_horizontal.xml
@@ -27,20 +27,6 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@drawable/ic_launcher_background" />
 
-        <androidx.appcompat.widget.AppCompatImageButton
-            android:id="@+id/btn_add_cart"
-            style="@style/RoundedMediumButton"
-            android:layout_width="@dimen/button_size"
-            android:layout_height="@dimen/button_size"
-            android:layout_marginHorizontal="@dimen/space_horizontal"
-            android:layout_marginVertical="@dimen/space_vertical"
-            android:tint="@{recently.added ? @color/white : @color/black}"
-            android:backgroundTint="@{recently.added ? @color/primary_accent : @color/white}"
-            android:elevation="2dp"
-            android:src="@{recently.added ? @drawable/ic_check : @drawable/ic_cart_disabled}"
-            app:layout_constraintBottom_toBottomOf="@id/iv_food"
-            app:layout_constraintEnd_toEndOf="@id/iv_food" />
-
         <TextView
             android:id="@+id/tv_food_title"
             style="@style/Body2"

--- a/presentation/src/main/res/layout/item_recently_horizontal.xml
+++ b/presentation/src/main/res/layout/item_recently_horizontal.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <import type="android.view.View" />
+
+        <variable
+            name="recently"
+            type="com.woowahan.ordering.domain.model.Recently" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="@dimen/image_large_size"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/iv_food"
+            android:layout_width="@dimen/image_large_size"
+            android:layout_height="0dp"
+            android:image="@{recently.thumbnail}"
+            android:scaleType="centerCrop"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/ic_launcher_background" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/btn_add_cart"
+            style="@style/RoundedMediumButton"
+            android:layout_width="@dimen/button_size"
+            android:layout_height="@dimen/button_size"
+            android:layout_marginHorizontal="@dimen/space_horizontal"
+            android:layout_marginVertical="@dimen/space_vertical"
+            android:tint="@{recently.added ? @color/white : @color/black}"
+            android:backgroundTint="@{recently.added ? @color/primary_accent : @color/white}"
+            android:elevation="2dp"
+            android:src="@{recently.added ? @drawable/ic_check : @drawable/ic_cart_disabled}"
+            app:layout_constraintBottom_toBottomOf="@id/iv_food"
+            app:layout_constraintEnd_toEndOf="@id/iv_food" />
+
+        <TextView
+            android:id="@+id/tv_food_title"
+            style="@style/Body2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_text_vertical"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@{recently.title}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_food"
+            tools:text="오리주물럭_반조리" />
+
+        <TextView
+            android:id="@+id/tv_discount_price"
+            style="@style/Body2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@{@string/currency_format(recently.discountedPrice)}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_food_title"
+            tools:text="12,640원" />
+
+        <TextView
+            android:id="@+id/tv_original_price"
+            style="@style/Caption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/space_text_horizontal"
+            android:lineThrough="@{true}"
+            android:text="@{@string/currency_format(recently.price)}"
+            android:visibility="@{recently.price > 0 ? View.VISIBLE : View.GONE}"
+            app:layout_constraintBaseline_toBaselineOf="@id/tv_discount_price"
+            app:layout_constraintStart_toEndOf="@id/tv_discount_price"
+            tools:text="15,800원" />
+
+        <TextView
+            android:id="@+id/tv_timestamp"
+            style="@style/Caption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:diffTimeStamp="@{recently.latestViewedTime}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_discount_price"
+            tools:text="1분 전" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
## Screen Type
- CartFragment, RecentlyViewedFragment

## Description
- close #92
-  RecentlyAdapter 리팩토링 및 클릭 시 바텀 시트, 화면 이동 구현

## Task
- RecentlyAdapter ViewHolder Grid/Horizontal Sealed Class로 분리
- Recently 아이템 클릭 시 화면 이동
- 장바구니 버튼 클릭 시 바텀 시트 띄우기

