### PR TITLE
[FIX] #106 - ItemDecorator 관련된 Grid Spacing 오류

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartRecentlyAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/cart/CartRecentlyAdapter.kt
@@ -7,6 +7,7 @@ import com.woowahan.ordering.databinding.ItemCartRecentlyBinding
 import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.domain.model.Recently
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader
+import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader.Companion.GRID
 import com.woowahan.ordering.util.dp
 
 class CartRecentlyAdapter(
@@ -25,10 +26,13 @@ class CartRecentlyAdapter(
     inner class CartRecentlyItemViewHolder(private val binding: ItemCartRecentlyBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        private val decoration = ItemSpacingDecoratorWithHeader(8.dp)
 
         fun bind(list: List<Recently>, seeAllClick: () -> Unit) = with(binding) {
             val adapter = RecentlyAdapter(RecentlyAdapter.RecentlyItemViewType.HorizontalItem)
+            val decoration = ItemSpacingDecoratorWithHeader(
+                spacing = 8.dp,
+                spaceAdapters = listOf(adapter)
+            )
             adapter.submitList(list)
             adapter.setOnClick(onDetailClick)
 

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemFoodBestViewHolder.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemFoodBestViewHolder.kt
@@ -13,14 +13,16 @@ class ItemFoodBestViewHolder(
     private val binding: ItemFoodBestBinding
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    private val decoration = ItemSpacingDecoratorWithHeader(8.dp)
-
     fun bind(
         best: Best,
         onDetailClick: (String, String) -> Unit,
         onCartClick: (Food) -> Unit
     ) {
         val adapter = FoodAdapter(FoodItemViewType.HorizontalItem)
+        val decoration = ItemSpacingDecoratorWithHeader(
+            spacing = 8.dp,
+            spaceAdapters = listOf(adapter)
+        )
         adapter.submitList(best.items)
         adapter.setOnClick(onDetailClick, onCartClick)
 

--- a/presentation/src/main/java/com/woowahan/ordering/ui/decorator/ItemSpacingDecoratorWithHeader.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/decorator/ItemSpacingDecoratorWithHeader.kt
@@ -7,43 +7,40 @@ import androidx.recyclerview.widget.RecyclerView
 
 class ItemSpacingDecoratorWithHeader(
     private val spacing: Int = 0,
-    private val removeSpacePosition: List<Int> = listOf(-1),
+    private val spaceAdapters: List<RecyclerView.Adapter<*>>,
     private val layoutDirection: Int = HORIZONTAL
 ) : RecyclerView.ItemDecoration() {
+    private fun isSpaceAdapter(adapter: RecyclerView.Adapter<*>?) = spaceAdapters.contains(adapter)
+
     override fun getItemOffsets(
         outRect: Rect,
         view: View,
         parent: RecyclerView,
         state: RecyclerView.State
     ) {
-        val adapterPosition = parent.getChildAdapterPosition(view)
-        val itemCount = parent.adapter?.itemCount ?: 0
-
-        with(outRect) {
-            if (layoutDirection == HORIZONTAL) {
-                if (!removeSpacePosition.contains(adapterPosition)) {
+        val viewHolder = parent.getChildViewHolder(view)
+        val adapterPosition = viewHolder.bindingAdapterPosition
+        val itemCount = viewHolder.bindingAdapter?.itemCount ?: 0
+        if (isSpaceAdapter(viewHolder.bindingAdapter)) {
+            with(outRect) {
+                if (layoutDirection == HORIZONTAL) {
                     left = spacing
                     if (adapterPosition == itemCount - 1)
                         right = spacing
                 }
-            }
 
-            if (layoutDirection == VERTICAL) {
-                if (!removeSpacePosition.contains(adapterPosition)) {
+                if (layoutDirection == VERTICAL) {
                     top = spacing
                     if (adapterPosition == itemCount - 1)
                         bottom = spacing
                 }
-            }
 
-            if (layoutDirection == GRID) {
-                if (!removeSpacePosition.contains(adapterPosition)) {
+                if (layoutDirection == GRID) {
                     val layoutManager = parent.layoutManager as? GridLayoutManager ?: return
 
                     val cols: Int = layoutManager.spanCount
                     val rows = itemCount / cols
 
-                    if (adapterPosition > cols + 1) outRect.top = spacing
                     outRect.left = if (adapterPosition % cols == 0) spacing else spacing / 2
                     outRect.right = if (adapterPosition % cols == cols - 1) spacing else spacing / 2
                     outRect.bottom = if (adapterPosition / cols == rows - 1) spacing else 0

--- a/presentation/src/main/java/com/woowahan/ordering/ui/decorator/ItemSpacingDecoratorWithHeader.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/decorator/ItemSpacingDecoratorWithHeader.kt
@@ -41,6 +41,7 @@ class ItemSpacingDecoratorWithHeader(
                     val cols: Int = layoutManager.spanCount
                     val rows = itemCount / cols
 
+                    outRect.top = spacing
                     outRect.left = if (adapterPosition % cols == 0) spacing else spacing / 2
                     outRect.right = if (adapterPosition % cols == cols - 1) spacing else spacing / 2
                     outRect.bottom = if (adapterPosition / cols == rows - 1) spacing else 0

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/recently/RecentlyViewedFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/cart/recently/RecentlyViewedFragment.kt
@@ -61,6 +61,7 @@ class RecentlyViewedFragment : Fragment() {
             rvRecently.addItemDecoration(
                 ItemSpacingDecoratorWithHeader(
                     spacing = 16.dp,
+                    spaceAdapters = listOf(adapter),
                     layoutDirection = GRID
                 )
             )

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
@@ -36,18 +36,6 @@ class MainDishFragment : Fragment() {
     private val typeAndFilterAdapter by lazy { TypeAndFilterAdapter() }
     private lateinit var foodAdapter: FoodAdapter
 
-    private val gridDecoration = ItemSpacingDecoratorWithHeader(
-        spacing = 18.dp,
-        removeSpacePosition = listOf(0, 1),
-        GRID
-    )
-
-    private val linearDecoration = ItemSpacingDecoratorWithHeader(
-        spacing = 18.dp,
-        removeSpacePosition = listOf(0, 1, 2),
-        VERTICAL
-    )
-
     private var onDetailClick: (title: String, hash: String) -> Unit = { _, _ -> }
     fun setOnDetailClick(onDetailClick: (title: String, hash: String) -> Unit) {
         this.onDetailClick = onDetailClick
@@ -90,6 +78,17 @@ class MainDishFragment : Fragment() {
         foodAdapter = FoodAdapter()
         val headerAdapter = HeaderAdapter("모두가 좋아하는\n든든한 메인 요리")
         val concatAdapter = ConcatAdapter(headerAdapter, typeAndFilterAdapter, foodAdapter)
+        val gridDecoration = ItemSpacingDecoratorWithHeader(
+            spacing = 18.dp,
+            spaceAdapters = listOf(foodAdapter),
+            GRID
+        )
+
+        val linearDecoration = ItemSpacingDecoratorWithHeader(
+            spacing = 18.dp,
+            spaceAdapters = listOf(foodAdapter),
+            VERTICAL
+        )
 
         typeAndFilterAdapter.setOnItemSelected {
             viewModel.getMenuList(Menu.Main, it)

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
@@ -97,7 +97,7 @@ class OtherDishFragment : Fragment() {
         }
         val decoration = ItemSpacingDecoratorWithHeader(
             spacing = 18.dp,
-            removeSpacePosition = listOf(0, 1),
+            spaceAdapters = listOf(foodAdapter),
             layoutDirection = GRID
         )
 

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/order/OrderListFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/order/OrderListFragment.kt
@@ -61,7 +61,7 @@ class OrderListFragment : Fragment() {
         rvOrderList.adapter = adapter
         rvOrderList.addItemDecoration(ItemSpacingDecoratorWithHeader(
             spacing = 9.dp,
-            removeSpacePosition = listOf(),
+            spaceAdapters = listOf(adapter),
             layoutDirection = VERTICAL
         ))
     }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/order/detail/OrderDetailFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/order/detail/OrderDetailFragment.kt
@@ -85,7 +85,7 @@ class OrderDetailFragment : Fragment() {
         rvOrderDetail.addItemDecoration(
             ItemSpacingDecoratorWithHeader(
                 spacing = 16.dp,
-                removeSpacePosition = listOf(0),
+                spaceAdapters = listOf(ordersAdapter),
                 layoutDirection = VERTICAL
             )
         )


### PR DESCRIPTION
## Screen Type
- 리사이클러뷰 어댑터

## Description
- close #106
-  ItemDecorator 관련된 Grid Spacing이 잘못 설정되는 오류

## Task
- [x] Top Spacing 추가
- [x] bindingAdapterPosition 사용
- [x] ItemDecorator 초기화 코드 수정

## 전달 사항
- 관련된 Grid 리사이클러뷰 아이템들의 Spacing이 모두 조절됩니다.
