### PR TITLE
[FEAT] 네트워크 연결이 없는 경우 대응

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
@@ -58,16 +58,24 @@ class DetailFragment : Fragment() {
         initFlow()
     }
 
-    private fun initData() = with(binding) {
+    private fun initData() {
         if (requireContext().hasNetwork()) {
             viewModel.getFoodDetail(hash)
-            layoutNoInternet.root.isVisible = false
-            rvDetail.isVisible = true
+            showRecyclerView()
         } else {
             requireContext().showToast(getString(R.string.no_internet_message))
-            layoutNoInternet.root.isVisible = true
-            rvDetail.isVisible = false
+            hideRecyclerView()
         }
+    }
+
+    private fun showRecyclerView() = with(binding) {
+        layoutNoInternet.root.isVisible = false
+        rvDetail.isVisible = true
+    }
+
+    private fun hideRecyclerView() = with(binding) {
+        layoutNoInternet.root.isVisible = true
+        rvDetail.isVisible = false
     }
 
     private fun initViews() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
@@ -5,12 +5,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.ConcatAdapter
+import com.woowahan.ordering.R
 import com.woowahan.ordering.databinding.FragmentDetailBinding
 import com.woowahan.ordering.ui.adapter.detail.DetailImagesFooterAdapter
 import com.woowahan.ordering.ui.adapter.detail.DetailInfoAdapter
@@ -19,8 +21,10 @@ import com.woowahan.ordering.ui.dialog.CartDialogFragment
 import com.woowahan.ordering.ui.dialog.IsExistsCartDialogFragment
 import com.woowahan.ordering.ui.fragment.cart.CartFragment
 import com.woowahan.ordering.ui.uistate.DetailUiState
-import com.woowahan.ordering.util.replace
 import com.woowahan.ordering.ui.viewmodel.DetailViewModel
+import com.woowahan.ordering.util.hasNetwork
+import com.woowahan.ordering.util.replace
+import com.woowahan.ordering.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -28,10 +32,11 @@ import kotlinx.coroutines.launch
 class DetailFragment : Fragment() {
 
     private val viewModel: DetailViewModel by viewModels()
-    private var binding: FragmentDetailBinding? = null
+    private var _binding: FragmentDetailBinding? = null
+    private val binding get() = requireNotNull(_binding)
 
-    private lateinit var hash: String
-    private lateinit var title: String
+    private val hash by lazy { requireArguments().getString(HASH, "") }
+    private val title by lazy { requireArguments().getString(TITLE, "") }
 
     private lateinit var detailThumbImagesAdapter: DetailThumbImagesAdapter
     private lateinit var detailInfoAdapter: DetailInfoAdapter
@@ -40,19 +45,48 @@ class DetailFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentDetailBinding.inflate(inflater)
-        return binding?.root
+    ): View {
+        _binding = FragmentDetailBinding.inflate(inflater)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        initData()
+        initViews()
         initFlow()
-        initArguments()
-        initRecyclerView()
+    }
 
-        viewModel.getFoodDetail(hash)
+    private fun initData() = with(binding) {
+        if (requireContext().hasNetwork()) {
+            viewModel.getFoodDetail(hash)
+            layoutNoInternet.root.isVisible = false
+            rvDetail.isVisible = true
+        } else {
+            requireContext().showToast(getString(R.string.no_internet_message))
+            layoutNoInternet.root.isVisible = true
+            rvDetail.isVisible = false
+        }
+    }
+
+    private fun initViews() {
+        binding.layoutNoInternet.btnRetry.setOnClickListener {
+            initData()
+        }
+        initRecyclerView()
+    }
+
+    private fun initRecyclerView() = with(binding) {
+        detailThumbImagesAdapter = DetailThumbImagesAdapter()
+        detailInfoAdapter = DetailInfoAdapter(viewModel, title)
+        detailImagesFooterAdapter = DetailImagesFooterAdapter()
+
+        rvDetail.adapter = ConcatAdapter(
+            detailThumbImagesAdapter,
+            detailInfoAdapter,
+            detailImagesFooterAdapter
+        )
     }
 
     private fun initFlow() {
@@ -100,19 +134,6 @@ class DetailFragment : Fragment() {
         }.show(parentFragmentManager, tag)
     }
 
-    private fun initArguments() = with(requireArguments()) {
-        hash = getString(HASH, "")
-        title = getString(TITLE, "")
-    }
-
-    private fun initRecyclerView() = with(binding!!) {
-        detailThumbImagesAdapter = DetailThumbImagesAdapter()
-        detailInfoAdapter = DetailInfoAdapter(viewModel, title)
-        detailImagesFooterAdapter = DetailImagesFooterAdapter()
-        val adapter = ConcatAdapter(detailThumbImagesAdapter, detailInfoAdapter, detailImagesFooterAdapter)
-        rvDetail.adapter = adapter
-    }
-
     private fun replaceToCart() {
         parentFragmentManager.replace(
             CartFragment::class.java,
@@ -123,7 +144,7 @@ class DetailFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     companion object {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
@@ -51,16 +51,24 @@ class BestFragment : Fragment() {
         initRecyclerView()
     }
 
-    private fun initData() = with(binding) {
+    private fun initData() {
         if (requireContext().hasNetwork()) {
             viewModel.getBestList()
-            layoutNoInternet.root.isVisible = false
-            rvBest.isVisible = true
+            showRecyclerView()
         } else {
             requireContext().showToast(getString(R.string.no_internet_message))
-            layoutNoInternet.root.isVisible = true
-            rvBest.isVisible = false
+            hideRecyclerView()
         }
+    }
+
+    private fun showRecyclerView() = with(binding) {
+        layoutNoInternet.root.isVisible = false
+        rvBest.isVisible = true
+    }
+
+    private fun hideRecyclerView() = with(binding) {
+        layoutNoInternet.root.isVisible = true
+        rvBest.isVisible = false
     }
 
     private fun initFlow() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
@@ -60,16 +60,24 @@ class MainDishFragment : Fragment() {
         initListener()
     }
 
-    private fun initData() = with(binding) {
+    private fun initData() {
         if (requireContext().hasNetwork()) {
             viewModel.getMenuList(Menu.Main)
-            layoutNoInternet.root.isVisible = false
-            rvMainDish.isVisible = true
+            showRecyclerView()
         } else {
             requireContext().showToast(getString(R.string.no_internet_message))
-            layoutNoInternet.root.isVisible = true
-            rvMainDish.isVisible = false
+            hideRecyclerView()
         }
+    }
+
+    private fun showRecyclerView() = with(binding) {
+        layoutNoInternet.root.isVisible = false
+        rvMainDish.isVisible = true
+    }
+
+    private fun hideRecyclerView() = with(binding) {
+        layoutNoInternet.root.isVisible = true
+        rvMainDish.isVisible = false
     }
 
     private fun initFlow() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
@@ -59,16 +59,24 @@ class OtherDishFragment : Fragment() {
         initRecyclerView()
     }
 
-    private fun initData() = with(binding) {
+    private fun initData() {
         if (requireContext().hasNetwork()) {
             viewModel.getMenuList(kind)
-            layoutNoInternet.root.isVisible = false
-            rvOtherDish.isVisible = true
+            showRecyclerView()
         } else {
             requireContext().showToast(getString(R.string.no_internet_message))
-            layoutNoInternet.root.isVisible = true
-            rvOtherDish.isVisible = false
+            hideRecyclerView()
         }
+    }
+
+    private fun showRecyclerView() = with(binding) {
+        layoutNoInternet.root.isVisible = false
+        rvOtherDish.isVisible = true
+    }
+
+    private fun hideRecyclerView() = with(binding) {
+        layoutNoInternet.root.isVisible = true
+        rvOtherDish.isVisible = false
     }
 
     private fun initFlow() {

--- a/presentation/src/main/java/com/woowahan/ordering/util/ToastUtil.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/util/ToastUtil.kt
@@ -1,0 +1,8 @@
+package com.woowahan.ordering.util
+
+import android.content.Context
+import android.widget.Toast
+
+fun Context.showToast(message: String) {
+    Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+}

--- a/presentation/src/main/res/drawable/ic_bad.xml
+++ b/presentation/src/main/res/drawable/ic_bad.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#787878"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8zM15.5,11c0.83,0 1.5,-0.67 1.5,-1.5S16.33,8 15.5,8 14,8.67 14,9.5s0.67,1.5 1.5,1.5zM8.5,11c0.83,0 1.5,-0.67 1.5,-1.5S9.33,8 8.5,8 7,8.67 7,9.5 7.67,11 8.5,11zM12,14c-2.33,0 -4.31,1.46 -5.11,3.5h10.22c-0.8,-2.04 -2.78,-3.5 -5.11,-3.5z"/>
+</vector>

--- a/presentation/src/main/res/layout/fragment_best.xml
+++ b/presentation/src/main/res/layout/fragment_best.xml
@@ -1,17 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context=".ui.fragment.home.best.BestFragment"
-    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+    tools:context=".ui.fragment.home.best.BestFragment">
+
+    <include
+        android:id="@+id/layout_no_internet"
+        layout="@layout/layout_no_internet"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
 
     <com.woowahan.ordering.ui.widget.OrientationAwareRecyclerView
         android:id="@+id/rv_best"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        tools:listitem="@layout/item_food_best"/>
+        tools:listitem="@layout/item_food_best" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_detail.xml
+++ b/presentation/src/main/res/layout/fragment_detail.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".ui.fragment.detail.DetailFragment">
+
+    <include
+        android:id="@+id/layout_no_internet"
+        layout="@layout/layout_no_internet"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
 
     <com.woowahan.ordering.ui.widget.OrientationAwareRecyclerView
         android:id="@+id/rv_detail"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_main_dish.xml
+++ b/presentation/src/main/res/layout/fragment_main_dish.xml
@@ -3,12 +3,18 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".ui.fragment.home.main.MainDishFragment">
+
+    <include
+        android:id="@+id/layout_no_internet"
+        layout="@layout/layout_no_internet"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_main_dish"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_other_dish.xml
+++ b/presentation/src/main/res/layout/fragment_other_dish.xml
@@ -5,6 +5,13 @@
     android:layout_height="match_parent"
     tools:context=".ui.fragment.home.other.OtherDishFragment">
 
+    <include
+        android:id="@+id/layout_no_internet"
+        layout="@layout/layout_no_internet"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_other_dish"
         android:layout_width="match_parent"

--- a/presentation/src/main/res/layout/layout_no_internet.xml
+++ b/presentation/src/main/res/layout/layout_no_internet.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/surface">
+
+        <ImageView
+            android:id="@+id/iv_warning"
+            android:layout_width="@dimen/image_medium_size"
+            android:layout_height="@dimen/image_medium_size"
+            android:src="@drawable/ic_bad"
+            app:layout_constraintBottom_toTopOf="@+id/tv_network_info_message"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <TextView
+            android:id="@+id/tv_network_info_message"
+            style="@style/Body1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_vertical"
+            android:text="@string/no_internet_message"
+            android:textAlignment="center"
+            app:layout_constraintBottom_toTopOf="@+id/btn_retry"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/iv_warning" />
+
+        <Button
+            android:id="@+id/btn_retry"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_vertical"
+            android:text="@string/no_internet_retry"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_network_info_message" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -52,4 +52,6 @@
     <string name="main_header_main_dish">모두가 좋아하는\n든든한 메인 요리</string>
     <string name="main_header_soup">정성이 담긴\n뜨끈뜨끈 국물 요리</string>
     <string name="main_header_side">식탁을 풍성하게 하는\n정갈한 밑반찬</string>
+    <string name="no_internet_message">네트워크가 연결되지 않았습니다.\nWi-Fi 또는 데이터를 활성화 해주세요.</string>
+    <string name="no_internet_retry">다시 시도</string>
 </resources>


### PR DESCRIPTION
## Screen Type
- 공통

## Description
- close #131
- 기본적인 로직은 아래와 같습니다. 
1. 기존에 작성해둔 네트워크 확장함수 사용하여 API 요청 전에 네트워크 연결을 확인
2. 연결이 있으면 데이터를 요청, 없으면 다른 화면 표출

- 네트워크 연결이 없을 때 표시할 레이아웃에는 '다시 시도' 버튼 존재
- '다시 시도' 버튼을 눌렀을 때도 마찬가지로 위의 1, 2 번을 차례로 수행
    - 그때도 여전히 연결이 없는 경우, 화면이 변하지 않아 멈춘건가 싶은 느낌이 들 수도 있다고 판단 -> 토스트 메시지로 사용자에게 알림

## 스크린샷
<p align="center">
<img width="300" alt="스크린샷 2022-08-21 오후 2 52 55" src="https://user-images.githubusercontent.com/78132126/185777679-8fae79e8-430e-4e81-804b-e819c74418a1.png">
<img width="300" alt="스크린샷 2022-08-21 오후 2 53 14" src="https://user-images.githubusercontent.com/78132126/185777682-a85ad81e-eff1-45ad-b715-941334849e80.png">
</p>


