### PR TITLE
[FIX] #143 - 기획전 payload 적용

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/DiffUtils.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/DiffUtils.kt
@@ -26,6 +26,10 @@ val bestDiffUtil = object : DiffUtil.ItemCallback<Best>() {
     override fun areContentsTheSame(oldItem: Best, newItem: Best): Boolean {
         return oldItem == newItem
     }
+
+    override fun getChangePayload(oldItem: Best, newItem: Best): Any? {
+        return oldItem != newItem
+    }
 }
 
 val stringDiffUtil = object : DiffUtil.ItemCallback<String>() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/BestFoodAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/BestFoodAdapter.kt
@@ -23,4 +23,21 @@ class BestFoodAdapter(
     override fun onBindViewHolder(holder: ItemFoodBestViewHolder, position: Int) {
         holder.bind(getItem(position))
     }
+
+    override fun onBindViewHolder(
+        holder: ItemFoodBestViewHolder,
+        position: Int,
+        payloads: MutableList<Any>
+    ) {
+        if (payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+            return
+        }
+
+        payloads.forEach {
+            if (it is Boolean) {
+                holder.submitList(getItem(position))
+            }
+        }
+    }
 }

--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemFoodBestViewHolder.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/viewholder/ItemFoodBestViewHolder.kt
@@ -32,4 +32,8 @@ class ItemFoodBestViewHolder(
             }
         }
     }
+
+    fun submitList(best: Best) {
+        adapter.submitList(best.items)
+    }
 }


### PR DESCRIPTION
## Screen Type
- 기획전

## Description
- close #143 
- 기획전 화면에도 payload 적용
- 외부 어댑터의 `onBindViewHolder(holder, positon, payloads)` 에서 화면을 다시 그리는 holder.bind() 가 아닌 submitList()로 내부 리사이클러뷰에 변경된 리스트만 전달하도록 하여 해결
