### PR TITLE
[FIX] #97 - onDestroy 필요없는 코드 제거

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/HomeFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/HomeFragment.kt
@@ -117,11 +117,6 @@ class HomeFragment : Fragment() {
         binding = null
     }
 
-    override fun onDestroy() {
-        tabLayoutMediator.detach()
-        super.onDestroy()
-    }
-
     companion object {
         const val TAG = "Home"
     }


### PR DESCRIPTION
## Screen Type
- HomeFragment

## Description
- close #97
- 홈 화면 수정 사항

## Task
- Binding 변수를 nullable하도록 수정 및 onDestroyView 호출 시 null로 초기화
- 리스트 아이템 헤더부분 Space 수정
- 기획전 아이템 Space 없어지는 버그 수정
- onDestroy 시 필요없는 초기화 코드 제거
