### PR TITLE
[FIX] #97 - 뷰페이저 onDestroy시 메모리 해제하기

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/HomeFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/HomeFragment.kt
@@ -29,10 +29,10 @@ class HomeFragment : Fragment() {
 
     private var binding: FragmentHomeBinding? = null
 
-    private val bestFragment = BestFragment.newInstance { showCartBottomSheet(it) }
-    private val mainDishFragment = MainDishFragment.newInstance { showCartBottomSheet(it) }
-    private val soupDishFragment = OtherDishFragment.newInstance(OtherKind.Soup) { showCartBottomSheet(it) }
-    private val sideDishFragment = OtherDishFragment.newInstance(OtherKind.Side) { showCartBottomSheet(it) }
+    private lateinit var bestFragment: BestFragment
+    private lateinit var mainDishFragment: MainDishFragment
+    private lateinit var soupDishFragment: OtherDishFragment
+    private lateinit var sideDishFragment: OtherDishFragment
 
     private lateinit var tabLayoutMediator: TabLayoutMediator
 
@@ -47,8 +47,16 @@ class HomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        initFragment()
         initListener()
         initViewPager()
+    }
+
+    private fun initFragment() {
+        bestFragment = BestFragment.newInstance { showCartBottomSheet(it) }
+        mainDishFragment = MainDishFragment.newInstance { showCartBottomSheet(it) }
+        soupDishFragment = OtherDishFragment.newInstance(OtherKind.Soup) { showCartBottomSheet(it) }
+        sideDishFragment = OtherDishFragment.newInstance(OtherKind.Side) { showCartBottomSheet(it) }
     }
 
     private fun initListener() {
@@ -110,6 +118,13 @@ class HomeFragment : Fragment() {
         CartDialogFragment.newInstance {
             replaceToCart()
         }.show(parentFragmentManager, CartDialogFragment.TAG)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        binding?.vpHome?.let {
+            it.adapter = null
+        }
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
@@ -21,6 +21,7 @@ import com.woowahan.ordering.ui.uistate.ListUiState
 import com.woowahan.ordering.ui.viewmodel.BestViewModel
 import com.woowahan.ordering.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -77,7 +78,7 @@ class BestFragment : Fragment() {
             viewModel.uiState.flowWithLifecycle(
                 lifecycle = lifecycle,
                 minActiveState = Lifecycle.State.STARTED
-            ).collect {
+            ).collectLatest {
                 when (it) {
                     is ListUiState.Refreshing -> {}
                     is ListUiState.List<Best> -> {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
@@ -29,6 +29,7 @@ import com.woowahan.ordering.ui.viewmodel.MainDishViewModel
 import com.woowahan.ordering.util.dp
 import com.woowahan.ordering.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -85,7 +86,7 @@ class MainDishFragment : Fragment() {
             viewModel.uiState.flowWithLifecycle(
                 lifecycle = lifecycle,
                 minActiveState = Lifecycle.State.STARTED
-            ).collect {
+            ).collectLatest {
                 when (it) {
                     is ListUiState.Refreshing -> {}
                     is ListUiState.List<Food> -> {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
@@ -27,6 +27,7 @@ import com.woowahan.ordering.ui.viewmodel.OtherDishViewModel
 import com.woowahan.ordering.util.dp
 import com.woowahan.ordering.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -91,7 +92,7 @@ class OtherDishFragment : Fragment() {
             viewModel.uiState.flowWithLifecycle(
                 lifecycle = lifecycle,
                 minActiveState = Lifecycle.State.STARTED
-            ).collect {
+            ).collectLatest {
                 when (it) {
                     is ListUiState.Refreshing -> {}
                     is ListUiState.List<Food> -> {


### PR DESCRIPTION
## Screen Type
- HomeFragment

## Description
- close #97
- 홈 화면 수정 사항

## Task
- Binding 변수를 nullable하도록 수정 및 onDestroyView 호출 시 null로 초기화
- 리스트 아이템 헤더부분 Space 수정
- 기획전 아이템 Space 없어지는 버그 수정
- 뷰페이저 onDestroy시 메모리 해제하기
