### PR TITLE
[FIX] #219 - 네트워크 연결 메시지가 화면에 장시간 남아있는 버그 수정

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
@@ -21,6 +21,7 @@ import com.woowahan.ordering.ui.adapter.detail.DetailThumbImagesAdapter
 import com.woowahan.ordering.ui.dialog.CartDialogFragment
 import com.woowahan.ordering.ui.dialog.IsExistsCartDialogFragment
 import com.woowahan.ordering.ui.fragment.cart.CartFragment
+import com.woowahan.ordering.ui.listener.setOnThrottleClickListener
 import com.woowahan.ordering.ui.uistate.DetailUiState
 import com.woowahan.ordering.ui.viewmodel.DetailViewModel
 import com.woowahan.ordering.util.hasNetwork
@@ -82,7 +83,7 @@ class DetailFragment : Fragment() {
     }
 
     private fun initViews() {
-        binding.layoutNoInternet.btnRetry.setOnClickListener {
+        binding.layoutNoInternet.btnRetry.setOnThrottleClickListener {
             initData()
         }
         initRecyclerView()

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/detail/DetailFragment.kt
@@ -1,6 +1,5 @@
 package com.woowahan.ordering.ui.fragment.detail
 
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -13,7 +12,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.ConcatAdapter
-import com.woowahan.ordering.R
 import com.woowahan.ordering.databinding.FragmentDetailBinding
 import com.woowahan.ordering.ui.adapter.detail.DetailImagesFooterAdapter
 import com.woowahan.ordering.ui.adapter.detail.DetailInfoAdapter
@@ -25,9 +23,8 @@ import com.woowahan.ordering.ui.listener.setOnThrottleClickListener
 import com.woowahan.ordering.ui.uistate.DetailUiState
 import com.woowahan.ordering.ui.viewmodel.DetailViewModel
 import com.woowahan.ordering.util.hasNetwork
-import com.woowahan.ordering.util.replace
 import com.woowahan.ordering.util.replaceWithPopBackstack
-import com.woowahan.ordering.util.showToast
+import com.woowahan.ordering.util.showSnackBar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -66,7 +63,7 @@ class DetailFragment : Fragment() {
             viewModel.getFoodDetail(hash)
             showRecyclerView()
         } else {
-            requireContext().showToast(getString(R.string.no_internet_message))
+            requireView().showSnackBar()
             hideRecyclerView()
         }
         viewModel.init()

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
@@ -20,7 +20,7 @@ import com.woowahan.ordering.ui.adapter.home.HeaderAdapter
 import com.woowahan.ordering.ui.listener.setOnThrottleClickListener
 import com.woowahan.ordering.ui.uistate.ListUiState
 import com.woowahan.ordering.ui.viewmodel.BestViewModel
-import com.woowahan.ordering.util.showToast
+import com.woowahan.ordering.util.showSnackBar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -63,7 +63,7 @@ class BestFragment : Fragment() {
     }
 
     private fun showNoInternetConnection() = with(binding) {
-        requireContext().showToast(getString(R.string.no_internet_message))
+        (requireView().parent as View).showSnackBar()
         layoutNoInternet.root.isVisible = true
         binding.srlBest.isRefreshing = false
         srlBest.isVisible = false

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/best/BestFragment.kt
@@ -17,6 +17,7 @@ import com.woowahan.ordering.domain.model.Best
 import com.woowahan.ordering.domain.model.Food
 import com.woowahan.ordering.ui.adapter.home.BestFoodAdapter
 import com.woowahan.ordering.ui.adapter.home.HeaderAdapter
+import com.woowahan.ordering.ui.listener.setOnThrottleClickListener
 import com.woowahan.ordering.ui.uistate.ListUiState
 import com.woowahan.ordering.ui.viewmodel.BestViewModel
 import com.woowahan.ordering.util.showToast
@@ -89,7 +90,7 @@ class BestFragment : Fragment() {
     }
 
     private fun initListener() {
-        binding.layoutNoInternet.btnRetry.setOnClickListener {
+        binding.layoutNoInternet.btnRetry.setOnThrottleClickListener {
             initData()
         }
         binding.srlBest.setOnRefreshListener {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
@@ -24,6 +24,7 @@ import com.woowahan.ordering.ui.adapter.home.TypeAndFilterAdapter
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader.Companion.GRID
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader.Companion.VERTICAL
+import com.woowahan.ordering.ui.listener.setOnThrottleClickListener
 import com.woowahan.ordering.ui.uistate.ListUiState
 import com.woowahan.ordering.ui.viewmodel.MainDishViewModel
 import com.woowahan.ordering.util.dp
@@ -159,7 +160,7 @@ class MainDishFragment : Fragment() {
     }
 
     private fun initListener() {
-        binding.layoutNoInternet.btnRetry.setOnClickListener {
+        binding.layoutNoInternet.btnRetry.setOnThrottleClickListener {
             initData()
         }
         binding.srlMainDish.setOnRefreshListener {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/main/MainDishFragment.kt
@@ -29,7 +29,7 @@ import com.woowahan.ordering.ui.uistate.ListUiState
 import com.woowahan.ordering.ui.viewmodel.MainDishViewModel
 import com.woowahan.ordering.util.dp
 import com.woowahan.ordering.util.removeAllItemDecorations
-import com.woowahan.ordering.util.showToast
+import com.woowahan.ordering.util.showSnackBar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -111,7 +111,7 @@ class MainDishFragment : Fragment() {
     }
 
     private fun showNoInternetConnection() = with(binding) {
-        requireContext().showToast(getString(R.string.no_internet_message))
+        (requireView().parent as View).showSnackBar()
         layoutNoInternet.root.isVisible = true
         binding.srlMainDish.isRefreshing = false
         srlMainDish.isVisible = false

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
@@ -23,6 +23,7 @@ import com.woowahan.ordering.ui.adapter.home.HeaderAdapter
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader
 import com.woowahan.ordering.ui.decorator.ItemSpacingDecoratorWithHeader.Companion.GRID
 import com.woowahan.ordering.ui.fragment.home.other.kind.OtherKind
+import com.woowahan.ordering.ui.listener.setOnThrottleClickListener
 import com.woowahan.ordering.ui.uistate.ListUiState
 import com.woowahan.ordering.ui.viewmodel.OtherDishViewModel
 import com.woowahan.ordering.util.dp
@@ -116,7 +117,7 @@ class OtherDishFragment : Fragment() {
     }
 
     private fun initListener() {
-        binding.layoutNoInternet.btnRetry.setOnClickListener {
+        binding.layoutNoInternet.btnRetry.setOnThrottleClickListener {
             initData()
         }
         binding.srlOtherDish.setOnRefreshListener {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
@@ -27,7 +27,7 @@ import com.woowahan.ordering.ui.listener.setOnThrottleClickListener
 import com.woowahan.ordering.ui.uistate.ListUiState
 import com.woowahan.ordering.ui.viewmodel.OtherDishViewModel
 import com.woowahan.ordering.util.dp
-import com.woowahan.ordering.util.showToast
+import com.woowahan.ordering.util.showSnackBar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -78,7 +78,7 @@ class OtherDishFragment : Fragment() {
     }
 
     private fun showNoInternetConnection() = with(binding) {
-        requireContext().showToast(getString(R.string.no_internet_message))
+        (requireView().parent as View).showSnackBar()
         layoutNoInternet.root.isVisible = true
         binding.srlOtherDish.isRefreshing = false
         srlOtherDish.isVisible = false

--- a/presentation/src/main/java/com/woowahan/ordering/util/SnackBarUtil.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/util/SnackBarUtil.kt
@@ -1,0 +1,13 @@
+package com.woowahan.ordering.util
+
+import android.view.View
+import com.google.android.material.snackbar.Snackbar
+import com.woowahan.ordering.R
+
+fun View.showSnackBar() {
+    Snackbar.make(
+        this,
+        R.string.no_internet_message,
+        Snackbar.LENGTH_SHORT
+    ).show()
+}


### PR DESCRIPTION
## Screen Type
- 공통

## Description
- close #219 
- 재시도 버튼을 여러번 누를 경우, 토스트 메시지가 화면에 장시간 남아있는 버그 수정
- 재시도 버튼 중복 클릭 방지
- 토스트는 정해진 시간동안 화면에 유지되고, 화면을 이동하거나 앱을 종료한 후에도 남아있을 수 있어 스낵바로 변경하여 해결