### PR TITLE
[FIX] #221 - 주문내역 배송 상태 업데이트 방법 추가

### DIFF
--- a/data/src/main/java/com/woowahan/ordering/data/entity/SimpleOrderEntity.kt
+++ b/data/src/main/java/com/woowahan/ordering/data/entity/SimpleOrderEntity.kt
@@ -6,4 +6,5 @@ data class SimpleOrderEntity(
     val thumbnail: String,
     val totalPrice: Long,
     val productCount: Int,
+    val isDelivered: Boolean
 )

--- a/data/src/main/java/com/woowahan/ordering/data/local/dao/OrderDao.kt
+++ b/data/src/main/java/com/woowahan/ordering/data/local/dao/OrderDao.kt
@@ -16,7 +16,7 @@ interface OrderDao {
     fun updateOrder(deliveryTime: Long, isDelivered: Boolean)
 
     @Query(
-        "SELECT c.title, c.thumbnail, o.deliveryTime, total(c.price) as totalPrice, count(o.deliveryTime) as productCount " +
+        "SELECT c.title, c.thumbnail, o.deliveryTime, o.isDelivered, total(c.price) as totalPrice, count(o.deliveryTime) as productCount " +
                 "FROM Orders as o LEFT JOIN Cart as c ON o.id = c.orderId " +
                 "GROUP BY o.deliveryTime ORDER BY o.deliveryTime DESC"
     )

--- a/data/src/main/java/com/woowahan/ordering/data/mapper/SimpleOrderMapper.kt
+++ b/data/src/main/java/com/woowahan/ordering/data/mapper/SimpleOrderMapper.kt
@@ -9,7 +9,8 @@ fun SimpleOrder.toEntity(): SimpleOrderEntity {
         deliveryTime,
         thumbnail,
         totalPrice,
-        productCount
+        productCount,
+        isDelivered
     )
 }
 
@@ -19,6 +20,7 @@ fun SimpleOrderEntity.toModel(): SimpleOrder {
         deliveryTime,
         thumbnail,
         totalPrice,
-        productCount
+        productCount,
+        isDelivered
     )
 }

--- a/domain/src/main/java/com/woowahan/ordering/domain/model/SimpleOrder.kt
+++ b/domain/src/main/java/com/woowahan/ordering/domain/model/SimpleOrder.kt
@@ -6,4 +6,5 @@ data class SimpleOrder(
     val thumbnail: String,
     val totalPrice: Long,
     val productCount: Int,
+    val isDelivered: Boolean
 )

--- a/presentation/src/main/java/com/woowahan/ordering/ui/binding/TextViewBindingAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/binding/TextViewBindingAdapter.kt
@@ -4,8 +4,8 @@ import android.graphics.Paint
 import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.databinding.BindingAdapter
-import com.woowahan.ordering.constants.getDiffFromNow
-import com.woowahan.ordering.constants.isTimeout
+import com.woowahan.ordering.util.getDiffFromNow
+import com.woowahan.ordering.util.isTimeout
 
 @BindingAdapter("android:lineThrough")
 fun TextView.setTextLineThrough(boolean: Boolean) {

--- a/presentation/src/main/java/com/woowahan/ordering/ui/binding/TextViewBindingAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/binding/TextViewBindingAdapter.kt
@@ -21,13 +21,6 @@ fun TextView.setDiffTimeStamp(timestamp: Long) {
     text = timestamp.getDiffFromNow()
 }
 
-@BindingAdapter("app:deliveryTime", "app:deliveringColor", "app:deliveredColor")
-fun TextView.setDeliveryTime(timestamp: Long, deliveringColor: Int, deliveredColor: Int) {
-    val now = System.currentTimeMillis()
-    text = if (timestamp > now) "배송 준비중" else "배송완료"
-    setTextColor(if (timestamp > now) deliveringColor else deliveredColor)
-}
-
 @BindingAdapter("android:isTimeout")
 fun TextView.setTimestampVisibility(timestamp: Long) {
     isVisible = timestamp.isTimeout()

--- a/presentation/src/main/java/com/woowahan/ordering/util/DateUtil.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/util/DateUtil.kt
@@ -1,4 +1,4 @@
-package com.woowahan.ordering.constants
+package com.woowahan.ordering.util
 
 fun Long.getDiffFromNow(): String {
     val now = System.currentTimeMillis()
@@ -24,5 +24,5 @@ fun Long.getDiffFromNow(): String {
 
 fun Long.isTimeout(): Boolean {
     val currentTime = System.currentTimeMillis()
-    return currentTime - this < 0
+    return currentTime - this <= 0
 }

--- a/presentation/src/main/res/layout/item_order_simple.xml
+++ b/presentation/src/main/res/layout/item_order_simple.xml
@@ -60,9 +60,8 @@
             style="@style/Body2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:deliveredColor="@{@color/tint_opposite}"
-            app:deliveringColor="@{@color/primary_accent}"
-            app:deliveryTime="@{simpleOrder.deliveryTime}"
+            android:text="@{simpleOrder.delivered ? @string/order_delivered : @string/order_delivering}"
+            android:textColor="@{simpleOrder.delivered ? @color/tint_opposite : @color/primary_accent}"
             app:layout_constraintStart_toStartOf="@id/tv_sum_of_price"
             app:layout_constraintTop_toBottomOf="@id/tv_sum_of_price"
             tools:text="배송 준비중" />

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="already_added_to_cart">이미 주문이 되어 있어요</string>
     <string name="simple_order_title">%s 외 %d개</string>
     <string name="order_reception">주문이 접수되었습니다.</string>
+    <string name="order_delivering">배송 준비중</string>
+    <string name="order_delivered">배송완료</string>
     <string name="delivery_success">배송이 완료되었습니다.</string>
     <string name="delivery_time_title">배송까지 남은 시간</string>
     <string name="delivery_time_format">%d분</string>


### PR DESCRIPTION
## Screen Type
- 주문내역

## Description
- close #221 
- 배달 상태 변수 추가후 데이터바인딩
- 불필요한 바인딩 어댑터 제거
- 남은 시간이 0초여도 표시되는 버그 수정