### PR TITLE
[FIX] #223 - 상세화면에서 뒤로 가면 리스트 반짝이는 버그 해결

### DIFF
--- a/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/CountAndFilterAdapter.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/adapter/home/CountAndFilterAdapter.kt
@@ -22,7 +22,7 @@ class CountAndFilterAdapter(
 
     fun setCount(count: Int) {
         this.count = count
-        notifyDataSetChanged()
+        notifyItemChanged(0)
     }
 
     inner class CountAndFilterViewHolder(

--- a/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
+++ b/presentation/src/main/java/com/woowahan/ordering/ui/fragment/home/other/OtherDishFragment.kt
@@ -37,17 +37,35 @@ class OtherDishFragment : Fragment() {
     private var _binding: FragmentOtherDishBinding? = null
     private val binding get() = requireNotNull(_binding)
     private val viewModel by viewModels<OtherDishViewModel>()
+    private val kind by lazy { requireArguments().get(OTHER_KIND) as OtherKind }
+
+    private val headerAdapter by lazy {
+        HeaderAdapter(
+            title = when (kind) {
+                OtherKind.Soup -> getString(R.string.main_header_soup)
+                OtherKind.Side -> getString(R.string.main_header_side)
+            }
+        )
+    }
 
     private val countAndFilterAdapter by lazy {
         CountAndFilterAdapter(
             onItemSelected = {
                 viewModel.setSortType(it)
-                initData()
             }
         )
     }
-    private lateinit var foodAdapter: FoodAdapter
-    private val kind by lazy { requireArguments().get(OTHER_KIND) as OtherKind }
+
+    private val foodAdapter by lazy {
+        FoodAdapter(
+            onDetailClick = onDetailClick,
+            onCartClick = openBottomSheet
+        )
+    }
+
+    private val concatAdapter by lazy {
+        ConcatAdapter(headerAdapter, countAndFilterAdapter, foodAdapter)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -61,9 +79,9 @@ class OtherDishFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         initData()
+        initRecyclerView()
         initFlow()
         initListener()
-        initRecyclerView()
     }
 
     private fun initData() {
@@ -125,16 +143,6 @@ class OtherDishFragment : Fragment() {
     }
 
     private fun initRecyclerView() = with(binding) {
-        val title = when (kind) {
-            OtherKind.Soup -> getString(R.string.main_header_soup)
-            OtherKind.Side -> getString(R.string.main_header_side)
-        }
-        val headerAdapter = HeaderAdapter(title)
-        foodAdapter = FoodAdapter(
-            onDetailClick = onDetailClick,
-            onCartClick = openBottomSheet
-        )
-        val concatAdapter = ConcatAdapter(headerAdapter, countAndFilterAdapter, foodAdapter)
         val decoration = ItemSpacingDecoratorWithHeader(
             spacing = 18.dp,
             spaceAdapters = listOf(foodAdapter),


### PR DESCRIPTION
## Screen Type
- 뜨끈한 국물요리, 정갈한 밑반찬

## Description
- close #223 
- CountAndFilterAdapter 의 `notifyDataSetChanged()` 를 `notifyItemChanged(0)` 으로 변경하여 해결
